### PR TITLE
CI: Adds build and deploy configs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,26 @@
+# Use the latest 2.1 version of CircleCI pipeline process engine.
+# See: https://circleci.com/docs/2.0/configuration-reference
+version: 2.1
+
+# Define a job to be invoked later in a workflow.
+# See: https://circleci.com/docs/2.0/configuration-reference/#jobs
+jobs:
+  say-hello:
+    # Specify the execution environment. You can specify an image from Dockerhub or use one of our Convenience Images from CircleCI's Developer Hub.
+    # See: https://circleci.com/docs/2.0/configuration-reference/#docker-machine-macos-windows-executor
+    docker:
+      - image: cimg/base:stable
+    # Add steps to the job
+    # See: https://circleci.com/docs/2.0/configuration-reference/#steps
+    steps:
+      - checkout
+      - run:
+          name: "Say hello"
+          command: "echo Hello, World!"
+
+# Invoke jobs via workflows
+# See: https://circleci.com/docs/2.0/configuration-reference/#workflows
+workflows:
+  say-hello-workflow:
+    jobs:
+      - say-hello

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,8 +2,11 @@
 # See: https://circleci.com/docs/2.0/configuration-reference
 version: 2.1
 
+orbs:
+  win: circleci/windows@5.0
+
 jobs:
-  build:
+  build-connector:
     executor:
       name: win/default
       shell: powershell.exe
@@ -16,7 +19,7 @@ jobs:
           root: /tmp/dir
           paths:
             - bin/*
-  deploy:
+  deploy-connector:
     executor:
       name: win/default
       shell: powershell.exe
@@ -31,16 +34,16 @@ jobs:
 workflows:
   build:
     jobs:
-      - build
+      - build-connector
   deploy:
     jobs:
-      - build:
+      - build-connector:
           filters:
             branches:
               ignore: /.*/ # For testing only: /ci\/.*/
             tags:
               only: /^([0-9]+)\.([0-9]+)\.([0-9]+)(?:-\w{1,10})?$/
-      - deploy:
+      - deploy-connector:
           filters:
             branches:
               ignore: /.*/ # For testing only: /ci\/.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
           name: "Build Data Connector"
           command: "msbuild Speckle.proj /restore /consoleloggerparameters:NoSummary /property:GenerateFullPaths=true"
       - store_artifacts:
-          path: /bin
+          path: ./bin
       - persist_to_workspace:
           root: ./
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,23 +13,29 @@ jobs:
     steps:
       - checkout
       - run:
+          name: "Set connector internal version"
+          command: |
+            $VERSION = if([string]::IsNullOrEmpty($env:CIRCLE_TAG)) { "2.0.0.$($env:WORKFLOW_NUM)" } else { $env:CIRCLE_TAG }
+            (Get-Content ./Speckle.pq).replace('[Version = "2.0.0"]', '[Version = "'+$($env:VERSION)+'"]') | Set-Content ./Speckle.pq
+      - run:
           name: "Build Data Connector"
           command: "msbuild Speckle.proj /restore /consoleloggerparameters:NoSummary /property:GenerateFullPaths=true"
       - persist_to_workspace:
-          root: ./
+          root: ./bin/
           paths:
-            - bin/*
+            - "*.mez"
+      - store_artifacts:
+          path: /bin/*.mez
   deploy-connector:
     executor:
       name: win/default
       shell: powershell.exe
     steps:
-      - checkout
       - attach_workspace:
           at: ./
       - run:
-          name: "Build Data Connector"
-          command: "msbuild Speckle.proj /restore /consoleloggerparameters:NoSummary /property:GenerateFullPaths=true"
+          name: "Deploy Data Connector"
+          command: "ls bin/"
 
 workflows:
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
       - run:
           name: "Publish Release on GitHub"
           command: |
-            ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} ./bin/
+            ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} ${CIRCLE_TAG} ./bin/
 workflows:
   build:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,25 +2,47 @@
 # See: https://circleci.com/docs/2.0/configuration-reference
 version: 2.1
 
-# Define a job to be invoked later in a workflow.
-# See: https://circleci.com/docs/2.0/configuration-reference/#jobs
 jobs:
-  say-hello:
-    # Specify the execution environment. You can specify an image from Dockerhub or use one of our Convenience Images from CircleCI's Developer Hub.
-    # See: https://circleci.com/docs/2.0/configuration-reference/#docker-machine-macos-windows-executor
-    docker:
-      - image: cimg/base:stable
-    # Add steps to the job
-    # See: https://circleci.com/docs/2.0/configuration-reference/#steps
+  build:
+    executor:
+      name: win/default
+      shell: powershell.exe
     steps:
       - checkout
       - run:
-          name: "Say hello"
-          command: "echo Hello, World!"
+          name: "Build Data Connector"
+          command: "msbuild Speckle.proj /restore /consoleloggerparameters:NoSummary /property:GenerateFullPaths=true"
+      - persist_to_workspace:
+          root: /tmp/dir
+          paths:
+            - bin/*
+  deploy:
+    executor:
+      name: win/default
+      shell: powershell.exe
+    steps:
+      - checkout
+      - attach_workspace:
+          at: ./
+      - run:
+          name: "Build Data Connector"
+          command: "msbuild Speckle.proj /restore /consoleloggerparameters:NoSummary /property:GenerateFullPaths=true"
 
-# Invoke jobs via workflows
-# See: https://circleci.com/docs/2.0/configuration-reference/#workflows
 workflows:
-  say-hello-workflow:
+  build:
     jobs:
-      - say-hello
+      - build
+  deploy:
+    jobs:
+      - build:
+          filters:
+            branches:
+              ignore: /.*/ # For testing only: /ci\/.*/
+            tags:
+              only: /^([0-9]+)\.([0-9]+)\.([0-9]+)(?:-\w{1,10})?$/
+      - deploy:
+          filters:
+            branches:
+              ignore: /.*/ # For testing only: /ci\/.*/
+            tags:
+              only: /^([0-9]+)\.([0-9]+)\.([0-9]+)(?:-\w{1,10})?$/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,3 +54,5 @@ workflows:
               ignore: /.*/ # For testing only: /ci\/.*/
             tags:
               only: /^([0-9]+)\.([0-9]+)\.([0-9]+)(?:-\w{1,10})?$/
+          requires:
+            - build-connector

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,19 +23,19 @@ jobs:
       - store_artifacts:
           path: /bin
       - persist_to_workspace:
-          root: ./bin
+          root: ./
           paths:
-            - /*
+            - bin/*
   deploy-connector:
     docker:
       - image: cibuilds/github:0.10
     steps:
       - attach_workspace:
-          at: ./artifacts
+          at: ./
       - run:
           name: "Publish Release on GitHub"
           command: |
-            ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} ./artifacts/
+            ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} ./bin/
 workflows:
   build:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,9 +21,9 @@ jobs:
           name: "Build Data Connector"
           command: "msbuild Speckle.proj /restore /consoleloggerparameters:NoSummary /property:GenerateFullPaths=true"
       - persist_to_workspace:
-          root: ./bin/
+          root: ./bin
           paths:
-            - "*.mez"
+            - /*
       - store_artifacts:
           path: /bin/*.mez
   deploy-connector:
@@ -32,7 +32,7 @@ jobs:
       shell: powershell.exe
     steps:
       - attach_workspace:
-          at: ./
+          at: ./artifacts
       - run:
           name: "Deploy Data Connector"
           command: "ls bin/"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,23 +20,22 @@ jobs:
       - run:
           name: "Build Data Connector"
           command: "msbuild Speckle.proj /restore /consoleloggerparameters:NoSummary /property:GenerateFullPaths=true"
+      - store_artifacts:
+          path: /bin
       - persist_to_workspace:
           root: ./bin
           paths:
             - /*
-      - store_artifacts:
-          path: /bin/*.mez
   deploy-connector:
-    executor:
-      name: win/default
-      shell: powershell.exe
+    docker:
+      - image: cibuilds/github:0.10
     steps:
       - attach_workspace:
           at: ./artifacts
       - run:
-          name: "Deploy Data Connector"
-          command: "ls bin/"
-
+          name: "Publish Release on GitHub"
+          command: |
+            ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} ./artifacts/
 workflows:
   build:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
           name: "Build Data Connector"
           command: "msbuild Speckle.proj /restore /consoleloggerparameters:NoSummary /property:GenerateFullPaths=true"
       - persist_to_workspace:
-          root: /tmp/dir
+          root: ./
           paths:
             - bin/*
   deploy-connector:

--- a/Speckle.pq
+++ b/Speckle.pq
@@ -1,4 +1,4 @@
-[Version = "0.0.14"]
+[Version = "2.0.0"]
 section Speckle;
 
 // The data source definition, used when connecting to any speckle server


### PR DESCRIPTION
Fixes #27 

Adds ci build jobs for normal commits, and a `deploy` job for tagged commits that will upload the artifacts to the existing release.

This assumes the release already exists in GitHub, as we use them to create the tags that will trigger the CI builds.