### PR TITLE
Fixes slow behaviour in `Speckle.GetByUrl`

### DIFF
--- a/speckle/api/Api.GetAllObjectChildren.pqm
+++ b/speckle/api/Api.GetAllObjectChildren.pqm
@@ -29,7 +29,7 @@ in
                         if (previous <> null and nextCursor = null) then
                             null
                         else
-                            Speckle.Api.GetObjectChildren(server, streamId, objectId, 50, nextCursor)
+                            Speckle.Api.GetObjectChildren(server, streamId, objectId, 1000, nextCursor)
                 in
                     page
         ) meta [server = server, streamId = streamId, objectId = objectId]

--- a/speckle/api/Api.GetObjectChildren.pqm
+++ b/speckle/api/Api.GetObjectChildren.pqm
@@ -15,22 +15,37 @@ let
                             Detail = [File = fileName, Error = e]
                         ]
 in
-    (server as text, streamId as text, objectId as text, optional limit as number, optional cursor as text) =>
+    (
+        server as text,
+        streamId as text,
+        objectId as text,
+        optional limit as number,
+        optional cursor as text,
+        optional select as list
+    ) =>
         let
-            query = "query($streamId: String!, $objectId: String!, $limit: Int, $cursor: String) { 
+            query = "query($streamId: String!, $objectId: String!, $limit: Int, $cursor: String, $select: [String]) { 
             stream( id: $streamId ) { 
                 object (id: $objectId) { 
-                    children(limit: $limit, cursor: $cursor) { 
+                    children(select: $select, limit: $limit, cursor: $cursor) { 
                         cursor
-                        objects { 
-                            data 
+                        objects {
+                            data
                         } 
                     } 
                 } 
             } 
         }",
             #"JSON" = Speckle.Api.Fetch(
-                server, query, [streamId = streamId, objectId = objectId, limit = limit, cursor = cursor]
+                server,
+                query,
+                [
+                    streamId = streamId,
+                    objectId = objectId,
+                    limit = limit,
+                    cursor = cursor,
+                    select = select
+                ]
             ),
             children = #"JSON"[stream][object][children],
             nextCursor = children[cursor],

--- a/speckle/helpers/CleanUpObjects.pqm
+++ b/speckle/helpers/CleanUpObjects.pqm
@@ -12,8 +12,6 @@
                         Record.RemoveFields(_[data], "totalChildrenCount", MissingField.Ignore) otherwise _[data]
                 ]
         ),
-        removeDatachunkRecords = List.RemoveItems(
-            removeTotals, List.FindText(removeTotals, "Speckle.Core.Models.DataChunk")
-        )
+        removed = List.Select(removeTotals, each _[data][speckle_type] <> "Speckle.Core.Models.DataChunk")
     in
-        removeDatachunkRecords
+        objects


### PR DESCRIPTION
Fixes #24

- Swapped a call in `CleanUpObjects` that was using `List.RemoveItems` and doing a look-up by index; with a much faster `List.Select`. 10X FASTER
- Increased the amount of children being fetched per page to 1000. The reason for this is 2-fold. Makes less calls to the server, but it's also de default size of the `data preview`, so it will in theory only make 1 call in the initial load.