### PR TITLE
fix: CNX-7606 Fixes missing `Data` column error

### DIFF
--- a/speckle/GetByUrl.pqm
+++ b/speckle/GetByUrl.pqm
@@ -1,5 +1,6 @@
 let
     Fetch = Extension.LoadFunction("Api.Fetch.pqm"),
+    GetObject = Extension.LoadFunction("Api.GetObject.pqm"),
     GetAllObjectChildren = Extension.LoadFunction("Api.GetAllObjectChildren.pqm"),
     GetObjectFromCommit = Extension.LoadFunction("GetObjectFromCommit.pqm"),
     GetObjectFromBranch = Extension.LoadFunction("GetObjectFromBranch.pqm"),
@@ -34,8 +35,7 @@ in
                     GetObjectFromBranch(server, id, stream[branch])
                 else
                     GetObjectFromBranch(server, id, "main"),
-            removeEmpty = Table.RemoveLastN(commitObjectsTable, 1),
-            addStreamUrl = Table.AddColumn(removeEmpty, "Stream URL", each server & "/streams/" & id),
+            addStreamUrl = Table.AddColumn(commitObjectsTable, "Stream URL", each server & "/streams/" & id),
             addParentObjectId = Table.AddColumn(
                 addStreamUrl, "Commit Object ID", each Value.Metadata(commitObjectsTable)[objectId]
             ),

--- a/speckle/api/Api.GetAllObjectChildren.pqm
+++ b/speckle/api/Api.GetAllObjectChildren.pqm
@@ -1,6 +1,7 @@
 let
     Table.GenerateByPage = Extension.LoadFunction("Table.GenerateByPage.pqm"),
     Speckle.Api.GetObjectChildren = Extension.LoadFunction("Api.GetObjectChildren.pqm"),
+    Speckle.Api.GetObject = Extension.LoadFunction("Api.GetObject.pqm"),
     Extension.LoadFunction = (fileName as text) =>
         let
             binary = Extension.Contents(fileName), asText = Text.FromBinary(binary)
@@ -19,17 +20,25 @@ in
     // After every page, we check the "nextCursor" record on the metadata of the previous request.
     // Table.GenerateByPage will keep asking for more pages until we return null.
     (server as text, streamId as text, objectId as text, optional cursor as text) as table =>
-        Table.GenerateByPage(
-            (previous) =>
-                let
-                    // if previous is null, then this is our first page of data
-                    nextCursor = if (previous = null) then cursor else Value.Metadata(previous)[Cursor]?,
-                    // if the cursor is null but the prevous page is not, we've reached the end
-                    page =
-                        if (previous <> null and nextCursor = null) then
-                            null
-                        else
-                            Speckle.Api.GetObjectChildren(server, streamId, objectId, 1000, nextCursor)
-                in
-                    page
-        ) meta [server = server, streamId = streamId, objectId = objectId]
+        let
+            parentObject = Speckle.Api.GetObject(server, streamId, objectId),
+            childrenTable = Table.GenerateByPage(
+                (previous) =>
+                    let
+                        // if previous is null, then this is our first page of data
+                        nextCursor = if (previous = null) then cursor else Value.Metadata(previous)[Cursor]?,
+                        // if the cursor is null but the prevous page is not, we've reached the end
+                        page =
+                            if (previous <> null and nextCursor = null) then
+                                null
+                            else
+                                Speckle.Api.GetObjectChildren(server, streamId, objectId, 1000, nextCursor)
+                    in
+                        page
+            ) meta [server = server, streamId = streamId, objectId = objectId],
+            parentTable = Table.FromRecords({[data = parentObject]})
+        in
+            if (Table.ColumnCount(childrenTable) = 0) then
+                parentTable
+            else
+                Table.Combine({parentTable, childrenTable})

--- a/speckle/api/Api.GetAllObjectChildren.pqm
+++ b/speckle/api/Api.GetAllObjectChildren.pqm
@@ -35,10 +35,12 @@ in
                                 Speckle.Api.GetObjectChildren(server, streamId, objectId, 1000, nextCursor)
                     in
                         page
-            ) meta [server = server, streamId = streamId, objectId = objectId],
-            parentTable = Table.FromRecords({[data = parentObject]})
+            ),
+            parentTable = Table.FromRecords({[data = parentObject]}),
+            resultTable =
+                if (Table.ColumnCount(childrenTable) = 0) then
+                    parentTable
+                else
+                    Table.Combine({parentTable, childrenTable})
         in
-            if (Table.ColumnCount(childrenTable) = 0) then
-                parentTable
-            else
-                Table.Combine({parentTable, childrenTable})
+            resultTable meta [server = server, streamId = streamId, objectId = objectId]

--- a/speckle/helpers/CleanUpObjects.pqm
+++ b/speckle/helpers/CleanUpObjects.pqm
@@ -14,4 +14,4 @@
         ),
         removed = List.Select(removeTotals, each _[data][speckle_type] <> "Speckle.Core.Models.DataChunk")
     in
-        removed
+        try removed otherwise objects


### PR DESCRIPTION
This issue was caused by the incorrect assumption that all commit objects would have detached children, which may not be the case when coming from scripts or SDKs without going through our connectors.

We'll also now ensure the parent object is included in the results as it is required to see the data if there are no detached children.