### PR TITLE
CNX-9016: Raise error when user inputs multi-model URL

### DIFF
--- a/speckle/helpers/ParseStreamUrl.pqm
+++ b/speckle/helpers/ParseStreamUrl.pqm
@@ -43,6 +43,7 @@ let
         let
             streamId = segments{1},
             modelList = segments{3},
+            isMultimodel = Text.Contains(modelList, ","),
             firstModel = Text.Split(modelList, ","){0},
             modelAndVersion = Text.Split(firstModel, "@"),
             modelId = modelAndVersion{0},
@@ -50,14 +51,22 @@ let
             model = if (modelId <> null) then GetModel(server, streamId, modelId) else null,
             urlType = GetUrlType(model[name], versionId, null)
         in
-            [
-                urlType = urlType,
-                server = server,
-                id = streamId,
-                branch = model[name],
-                commit = versionId,
-                object = null
-            ]
+            if isMultimodel then
+                error
+                    Error.Record(
+                        "NotSupported",
+                        "Multi-model URLs are not supported.",
+                        "Try to select just one single model in the web app and paste that in."
+                    )
+            else
+                [
+                    urlType = urlType,
+                    server = server,
+                    id = streamId,
+                    branch = model[name],
+                    commit = versionId,
+                    object = null
+                ]
 in
     (url as text) as record =>
         let


### PR DESCRIPTION
Raises a new error when user inputs multi-model URL. Previously we were silently falling back to just the first model.

![Screenshot 2024-02-26 at 17 34 29](https://github.com/specklesystems/speckle-powerbi/assets/2316535/a5b9d325-e7d4-4e7b-9329-b076496424ac)
