### PR TITLE
fix: Ensure old .mez connector is removed upon installation

### DIFF
--- a/tools/powerbi.iss
+++ b/tools/powerbi.iss
@@ -59,3 +59,7 @@ Source: "{#Bin}Speckle.pqx"; DestDir: "{#CustomConnectorFolder}";
 ; TODO: Including the thumbprint in the registry will enable this running in higher security environments.
 ; Currently blocked because of MakePQX.exe not being ready to work with online CSP's like Digicert Keylocker.
 ; #include "includes\registry-thumbprint-edit.iss"
+
+[InstallDelete]
+; Remove old .mez file connector to prevent conflicts
+Type: filesandordirs; Name: "{#CustomConnectorFolder}\Speckle.mez"


### PR DESCRIPTION
Ensures old mez file is deleted before copying over the new pqx file data connector