### PR TITLE
Pass service as artifact

### DIFF
--- a/.github/workflows/build_powerbi.yml
+++ b/.github/workflows/build_powerbi.yml
@@ -100,6 +100,11 @@ jobs:
         with:
           name: powerbi-visual
           path: artifacts/
+      - name: pull powerbi-service
+        run: |
+          curl --location --output powerbi-service.zip https://releases.speckle.dev/services/powerbi-service/powerbi-service-0.1.0.zip # bump this version as needed
+          unzip powerbi-service.zip -d artifacts
+
       - name: Zip artifacts
         run: |
           cd artifacts && zip -r ../powerbi.zip .


### PR DESCRIPTION
Downloads the `Speckle.Services.PowerBi` zip (build by [speckle-powerbi-service](https://github.com/specklesystems/speckle-powerbi-service/blob/main/.github/workflows/release.yml)) and uploads as an artifact before triggering [connector-installers](https://github.com/specklesystems/connector-installers/blob/main/.github/workflows/build_powerbi.yml) ci.