### PR TITLE
fix: rename the input field

### DIFF
--- a/src/powerbi-data-connector/speckle/GetByUrl.pqm
+++ b/src/powerbi-data-connector/speckle/GetByUrl.pqm
@@ -30,7 +30,7 @@
         StructuredData = GetStructuredData(url),
 
         // rename column based on send status
-        NewColumnName = "Viewer Data ID",
-        Result = Table.RenameColumns(StructuredData, {{"Viewer Data ID", NewColumnName}})
+        NewColumnName = "Version Object ID",
+        Result = Table.RenameColumns(StructuredData, {{"Version Object ID", NewColumnName}})
     in
         Result

--- a/src/powerbi-data-connector/speckle/api/GetStructuredData.pqm
+++ b/src/powerbi-data-connector/speckle/api/GetStructuredData.pqm
@@ -55,7 +55,7 @@
                     [
                         #"Object IDs" = record[id], // Object IDs
                         #"Speckle Type" = record[speckle_type], // Speckle Type
-                        #"Viewer Data ID" = rootId,
+                        #"Version Object ID" = rootId,
                         data = Record.RemoveFields(record, fieldsToRemoveForThisRecord) // Data
                     ]
             )

--- a/src/powerbi-visual/capabilities.json
+++ b/src/powerbi-visual/capabilities.json
@@ -1,7 +1,7 @@
 {
   "dataRoles": [
     {
-      "displayName": "Viewer Data ID",
+      "displayName": "Version Object ID",
       "kind": "Grouping",
       "name": "rootObjectId"
     },


### PR DESCRIPTION
renames the input field of the visual and query column name from "Viewer Data ID" to "Version Object ID"