### PR TITLE
Feat(mixpanel): get user info from service

### DIFF
--- a/src/powerbi-data-connector/Speckle.query.pq
+++ b/src/powerbi-data-connector/Speckle.query.pq
@@ -1,7 +1,8 @@
 ﻿// use this file to write queries to test your data connector
+
+// NOTE! for tests, be make sure you put here a model that in private project to make sure all good.
 let
     result = Speckle.GetByUrl(
-
         "https://latest.speckle.systems/projects/126cd4b7bb/models/85c44d39c6"
     )
 in

--- a/src/powerbi-data-connector/speckle/api/GetModel.pqm
+++ b/src/powerbi-data-connector/speckle/api/GetModel.pqm
@@ -43,6 +43,7 @@
                             items {
                                 id
                                 referencedObject
+                                sourceApplication
                             }
                         }
                     }
@@ -57,6 +58,7 @@
                         version(id: $versionId) {
                             id
                             referencedObject
+                            sourceApplication
                         }
                     }
                 }
@@ -105,14 +107,16 @@
                 modelId = JsonResponse[data][project][model][id],
                 modelName = JsonResponse[data][project][model][name],
                 versionId = JsonResponse[data][project][model][versions][items]{0}[id],
-                rootObjectId = JsonResponse[data][project][model][versions][items]{0}[referencedObject]
+                rootObjectId = JsonResponse[data][project][model][versions][items]{0}[referencedObject],
+                sourceApplication = JsonResponse[data][project][model][versions][items]{0}[sourceApplication]
             ]
         else
             [
                 modelId = JsonResponse[data][project][model][id],
                 modelName = JsonResponse[data][project][model][name],
                 versionId = JsonResponse[data][project][model][version][id],
-                rootObjectId = JsonResponse[data][project][model][version][referencedObject]
+                rootObjectId = JsonResponse[data][project][model][version][referencedObject],
+                sourceApplication = JsonResponse[data][project][model][versions][items][sourceApplication]
             ]
     in
         result

--- a/src/powerbi-data-connector/speckle/api/GetUser.pqm
+++ b/src/powerbi-data-connector/speckle/api/GetUser.pqm
@@ -26,7 +26,7 @@ in
             parsedUrl = Parser(url),
             server = parsedUrl[baseUrl],
             
-            apiKey = try Extension.CurrentCredential()[Key] otherwise null,
+            apiKey = Extension.CurrentCredential(),
             
             query = "query {
                     activeUser {
@@ -61,5 +61,6 @@ in
                     UserName = JsonResponse[data][activeUser][name],
                     ServerName = JsonResponse[data][serverInfo][name],
                     ServerCompany = JsonResponse[data][serverInfo][company],
-                    ServerVersion = JsonResponse[data][serverInfo][version]
+                    ServerVersion = JsonResponse[data][serverInfo][version],
+                    Token = apiKey[access_token]
                 ]

--- a/src/powerbi-data-connector/speckle/api/SendToServer.pqm
+++ b/src/powerbi-data-connector/speckle/api/SendToServer.pqm
@@ -53,9 +53,12 @@
         // Prepare request data
         requestData = Json.FromValue([
             Url = url,
+            Server = parsedUrl[baseUrl],
+            Email = userEmail, // TODO: can't get it
             ProjectId = parsedUrl[projectId],
             ObjectId = modelInfo[rootObjectId],
-            token = apiKey
+            SourceApplication = modelInfo[sourceApplication],
+            Token = apiKey // TODO: why it was lowercased before?
         ]),
         
         // Send request to local server

--- a/src/powerbi-data-connector/speckle/api/SendToServer.pqm
+++ b/src/powerbi-data-connector/speckle/api/SendToServer.pqm
@@ -30,23 +30,25 @@
         // Get user email from credentials
         userEmail = try Extension.CurrentCredential()[Username] otherwise null,
         
+        // TODO: Dogukan: smth wrong here. Also we will need to have sourceApplication from modelInfo and send to desktop service
+
         // Send mixpanel info to endpoint
-        UserInfoResponse = Web.Contents(
-            "http://127.0.0.1:29364/user-info",
-            [
-                Headers = [
-                    #"Content-Type" = "application/json",
-                    #"Method" = "POST",
-                    #"Authorization" = if apiKey = null then "" else Text.Format("Bearer #{0}", {apiKey})
-                ],
-                Content = Json.FromValue([
-                    email = userEmail,
-                    server = parsedUrl[baseUrl],
-                    objectId = modelInfo[rootObjectId]
-                ]),
-                ManualStatusHandling = {400, 401, 403, 404, 500}
-            ]
-        ),
+        // UserInfoResponse = Web.Contents(
+        //     "http://127.0.0.1:29364/user-info",
+        //     [
+        //         Headers = [
+        //             #"Content-Type" = "application/json",
+        //             #"Method" = "POST",
+        //             #"Authorization" = if apiKey = null then "" else Text.Format("Bearer #{0}", {apiKey})
+        //         ],
+        //         Content = Json.FromValue([
+        //             email = userEmail,
+        //             server = parsedUrl[baseUrl],
+        //             objectId = modelInfo[rootObjectId]
+        //         ]),
+        //         ManualStatusHandling = {400, 401, 403, 404, 500}
+        //     ]
+        // ),
         
         // Prepare request data
         requestData = Json.FromValue([

--- a/src/powerbi-data-connector/speckle/api/SendToServer.pqm
+++ b/src/powerbi-data-connector/speckle/api/SendToServer.pqm
@@ -30,7 +30,7 @@
         // Get user email from credentials
         userEmail = try Extension.CurrentCredential()[Username] otherwise null,
         
-        // TODO: Dogukan: smth wrong here. Also we will need to have sourceApplication from modelInfo and send to desktop service
+        // TODO: Dogukan: smth wrong here. Also we will need to have sourceApplication from modelInfo and send to desktop service to track workflows
 
         // Send mixpanel info to endpoint
         // UserInfoResponse = Web.Contents(

--- a/src/powerbi-data-connector/speckle/api/SendToServer.pqm
+++ b/src/powerbi-data-connector/speckle/api/SendToServer.pqm
@@ -3,6 +3,7 @@
         // Import required functions
         GetModel = Extension.LoadFunction("GetModel.pqm"),
         Parser = Extension.LoadFunction("Parser.pqm"),
+        GetUser = Extension.LoadFunction("GetUser.pqm"),
          // the logic for importing functions from other files
         Extension.LoadFunction = (fileName as text) =>
             let
@@ -23,42 +24,23 @@
         // Get model info and parsed URL
         modelInfo = GetModel(url),
         parsedUrl = Parser(url),
+        userInfo = GetUser(url),
         
         // Get API key if available
-        apiKey = try Extension.CurrentCredential()[Key] otherwise null,
+        apiKey = userInfo[Token],
         
         // Get user email from credentials
-        userEmail = try Extension.CurrentCredential()[Username] otherwise null,
-        
-        // TODO: Dogukan: smth wrong here. Also we will need to have sourceApplication from modelInfo and send to desktop service to track workflows
-
-        // Send mixpanel info to endpoint
-        // UserInfoResponse = Web.Contents(
-        //     "http://127.0.0.1:29364/user-info",
-        //     [
-        //         Headers = [
-        //             #"Content-Type" = "application/json",
-        //             #"Method" = "POST",
-        //             #"Authorization" = if apiKey = null then "" else Text.Format("Bearer #{0}", {apiKey})
-        //         ],
-        //         Content = Json.FromValue([
-        //             email = userEmail,
-        //             server = parsedUrl[baseUrl],
-        //             objectId = modelInfo[rootObjectId]
-        //         ]),
-        //         ManualStatusHandling = {400, 401, 403, 404, 500}
-        //     ]
-        // ),
+        userEmail = userInfo[UserEmail],
         
         // Prepare request data
         requestData = Json.FromValue([
             Url = url,
             Server = parsedUrl[baseUrl],
-            Email = userEmail, // TODO: can't get it
+            Email = userEmail,
             ProjectId = parsedUrl[projectId],
             ObjectId = modelInfo[rootObjectId],
             SourceApplication = modelInfo[sourceApplication],
-            Token = apiKey // TODO: why it was lowercased before?
+            Token = apiKey 
         ]),
         
         // Send request to local server

--- a/src/powerbi-visual/capabilities.json
+++ b/src/powerbi-visual/capabilities.json
@@ -72,7 +72,7 @@
         "speckleObjects": {
           "type": { "text": true }
         },
-        "userInfo": {
+        "receiveInfo": {
           "type": { "text": true }
         }
       }

--- a/src/powerbi-visual/src/plugins/viewer.ts
+++ b/src/powerbi-visual/src/plugins/viewer.ts
@@ -7,6 +7,7 @@ import {
   CanonicalView
 } from '@speckle/viewer'
 import { SpeckleObjectsOfflineLoader } from '@src/laoder/SpeckleObjectsOfflineLoader'
+import { useVisualStore } from '@src/store/visualStore'
 import { Tracker } from '@src/utils/mixpanel'
 import { createNanoEvents, Emitter } from 'nanoevents'
 import { ColorPicker } from 'powerbi-visuals-utils-formattingmodel/lib/FormattingSettingsComponents'
@@ -144,7 +145,8 @@ export class ViewerHandler {
     //@ts-ignore
     const loader = new SpeckleObjectsOfflineLoader(this.viewer.getWorldTree(), objects)
     await this.viewer.loadObject(loader, true)
-    Tracker.dataLoaded()
+    const store = useVisualStore()
+    Tracker.dataLoaded({ sourceHostApp: store.receiveInfo.sourceApplication })
   }
 
   private handlePing = (message: string) => {

--- a/src/powerbi-visual/src/store/visualStore.ts
+++ b/src/powerbi-visual/src/store/visualStore.ts
@@ -133,7 +133,7 @@ export const useVisualStore = defineStore('visualStore', () => {
           objectName: 'storedData',
           properties: {
             speckleObjects: compressedChunks,
-            userInfo: JSON.stringify(receiveInfo.value)
+            receiveInfo: JSON.stringify(receiveInfo.value)
           },
           selector: null
         }

--- a/src/powerbi-visual/src/store/visualStore.ts
+++ b/src/powerbi-visual/src/store/visualStore.ts
@@ -1,7 +1,7 @@
 import { IViewerEvents } from '@src/plugins/viewer'
 import { SpeckleDataInput } from '@src/types'
 import { zipJSONChunks } from '@src/utils/compression'
-import { UserInfo } from '@src/utils/matrixViewUtils'
+import { ReceiveInfo } from '@src/utils/matrixViewUtils'
 import { defineStore } from 'pinia'
 import { ref, shallowRef } from 'vue'
 
@@ -22,7 +22,7 @@ export const useVisualStore = defineStore('visualStore', () => {
   const isViewerReadyToLoad = ref<boolean>(false)
   const isViewerObjectsLoaded = ref<boolean>(false)
   const viewerReloadNeeded = ref<boolean>(false)
-  const userInfo = ref<UserInfo>(undefined)
+  const receiveInfo = ref<ReceiveInfo>(undefined)
   const fieldInputState = ref<FieldInputState>({
     rootObjectId: false,
     objectIds: false,
@@ -52,7 +52,7 @@ export const useVisualStore = defineStore('visualStore', () => {
     host.value = hostToSet
   }
 
-  const setUserInfo = (newUserInfo: UserInfo) => (userInfo.value = newUserInfo)
+  const setReceiveInfo = (newReceiveInfo: ReceiveInfo) => (receiveInfo.value = newReceiveInfo)
 
   /**
    * Ideally one time set when onMounted of `ViewerWrapper.vue` component
@@ -133,7 +133,7 @@ export const useVisualStore = defineStore('visualStore', () => {
           objectName: 'storedData',
           properties: {
             speckleObjects: compressedChunks,
-            userInfo: JSON.stringify(userInfo.value)
+            userInfo: JSON.stringify(receiveInfo.value)
           },
           selector: null
         }
@@ -152,7 +152,7 @@ export const useVisualStore = defineStore('visualStore', () => {
 
   return {
     host,
-    userInfo,
+    receiveInfo,
     objectsFromStore,
     isViewerInitialized,
     isViewerReadyToLoad,
@@ -166,7 +166,7 @@ export const useVisualStore = defineStore('visualStore', () => {
     loadingProgress,
     loadObjectsFromFile,
     setHost,
-    setUserInfo,
+    setReceiveInfo,
     setViewerReloadNeeded,
     setObjectsFromStore,
     writeObjectsToFile,

--- a/src/powerbi-visual/src/utils/hostAppSlug.ts
+++ b/src/powerbi-visual/src/utils/hostAppSlug.ts
@@ -1,0 +1,55 @@
+/**
+ * @param appname application name with its version, i.e. `Rhino 7`, `Revit 2024`
+ * @returns slug
+ */
+export function getSlugFromHostAppNameAndVersion(appname: string) {
+  if (!appname) {
+    return 'other'
+  }
+
+  // delete space if any
+  appname = appname.toLowerCase().replace(/\s/g, '')
+
+  // `NEW CONNECTOR CHECK`
+  const keywords = [
+    'dynamo',
+    'revit',
+    'autocad',
+    'civil',
+    'rhino',
+    'grasshopper',
+    'unity',
+    'gsa',
+    'microstation',
+    'openroads',
+    'openrail',
+    'openbuildings',
+    'etabs',
+    'sap',
+    'csibridge',
+    'safe',
+    'teklastructures',
+    'dxf',
+    'excel',
+    'unreal',
+    'powerbi',
+    'blender',
+    'qgis',
+    'arcgis',
+    'sketchup',
+    'archicad',
+    'topsolid',
+    'python',
+    'net',
+    'navisworks',
+    'advancesteel'
+  ]
+
+  for (const keyword of keywords) {
+    if (appname.includes(keyword)) {
+      return keyword
+    }
+  }
+
+  return appname
+}

--- a/src/powerbi-visual/src/utils/matrixViewUtils.ts
+++ b/src/powerbi-visual/src/utils/matrixViewUtils.ts
@@ -348,26 +348,7 @@ export async function processMatrixView(
     visualStore.setViewerReadyToLoad()
     visualStore.setLoadingProgress('Loading', null)
 
-    // old way
-
-    // try {
-    //   const res = await fetch(`http://localhost:29364/get-data/${id}`)
-    //   const data = (await res.json()) as unknown as Data
-    //   objects = data.objects
-    //   visualStore.setUserInfo(data.userInfo)
-    //   visualStore.setViewerReloadNeeded() // they should be marked as deferred action bc of update function complexity.
-    // } catch (error) {
-    //   // TODO: global toast notification to throw message for local server (manager)
-    //   console.log("Objects couldn't retrieved from local server.")
-    // }
-
-    // stream data 1
-    // objects = await fetchOneByOne(id)
-
-    // stream data 2 - batched
-    // objects = await fetchDataInBatches(id, 100)
-
-    // stream data 3
+    // stream data
     objects = await fetchStreamedData(id)
 
     const receiveInfo = await getReceiveInfo(id)

--- a/src/powerbi-visual/src/utils/mixpanel.ts
+++ b/src/powerbi-visual/src/utils/mixpanel.ts
@@ -18,12 +18,12 @@ export enum SettingsChangedType {
 export class Tracker {
   public static async track(event: string, properties: any = {}) {
     const visualStore = useVisualStore()
-    const userInfo = visualStore.userInfo
+    const receiveInfo = visualStore.receiveInfo
     let tempProperties = properties
-    if (userInfo) {
-      const hashedEmail = '@' + md5(userInfo.userEmail.toLowerCase() as string).toUpperCase()
+    if (receiveInfo) {
+      const hashedEmail = '@' + md5(receiveInfo.userEmail.toLowerCase() as string).toUpperCase()
       const hashedServer = md5(
-        new URL(userInfo.serverUrl).hostname.toLowerCase() as string
+        new URL(receiveInfo.serverUrl).hostname.toLowerCase() as string
       ).toUpperCase()
       tempProperties = {
         ...tempProperties, // eslint-disable-next-line camelcase
@@ -64,7 +64,7 @@ export class Tracker {
     }
   }
 
-  public static dataLoaded() {
-    return this.track('Receive')
+  public static dataLoaded(properties = {}) {
+    return this.track('Receive', properties)
   }
 }

--- a/src/powerbi-visual/src/visual.ts
+++ b/src/powerbi-visual/src/visual.ts
@@ -107,13 +107,13 @@ export class Visual implements IVisual {
                 options.dataViews[0].metadata.objects.storedData?.speckleObjects as string
               ).split(',')
               const objectsFromFile = unzipJSONChunks(chunks)
-              //const objectsFromFile = []
-              // chunks.forEach((c) => objectsFromFile.push(unzipJSONChunk(c)))
+
+              // get receive info from file for mixpanel
               try {
-                const userInfoFromFile = JSON.parse(
-                  options.dataViews[0].metadata.objects.storedData?.userInfo as string
+                const receiveInfoFromFile = JSON.parse(
+                  options.dataViews[0].metadata.objects.storedData?.receiveInfo as string
                 ) as ReceiveInfo
-                visualStore.setReceiveInfo(userInfoFromFile)
+                visualStore.setReceiveInfo(receiveInfoFromFile)
               } catch (error) {
                 console.warn(error)
                 console.log('missing mixpanel info')

--- a/src/powerbi-visual/src/visual.ts
+++ b/src/powerbi-visual/src/visual.ts
@@ -9,7 +9,7 @@ import { selectionHandlerKey, tooltipHandlerKey } from 'src/injectionKeys'
 
 import { Tracker } from './utils/mixpanel'
 import { SpeckleDataInput } from './types'
-import { processMatrixView, UserInfo, validateMatrixView } from './utils/matrixViewUtils'
+import { processMatrixView, ReceiveInfo, validateMatrixView } from './utils/matrixViewUtils'
 import { SpeckleVisualSettingsModel } from './settings/visualSettingsModel'
 
 import TooltipHandler from './handlers/tooltipHandler'
@@ -112,8 +112,8 @@ export class Visual implements IVisual {
               try {
                 const userInfoFromFile = JSON.parse(
                   options.dataViews[0].metadata.objects.storedData?.userInfo as string
-                ) as UserInfo
-                visualStore.setUserInfo(userInfoFromFile)
+                ) as ReceiveInfo
+                visualStore.setReceiveInfo(userInfoFromFile)
               } catch (error) {
                 console.warn(error)
                 console.log('missing mixpanel info')


### PR DESCRIPTION
Data connector passes more rich data over `/download` post to log it into dictionary for visual, then visual calls the `/user-info` to be able to track receive event.