### PR TITLE
Fix: do not stream data for saved files

### DIFF
--- a/src/powerbi-visual/src/store/visualStore.ts
+++ b/src/powerbi-visual/src/store/visualStore.ts
@@ -18,10 +18,14 @@ export const useVisualStore = defineStore('visualStore', () => {
   const host = shallowRef<powerbi.extensibility.visual.IVisualHost>()
   const loadingProgress = ref<{ summary: string; progress: number }>(undefined)
   const objectsFromStore = ref<object[]>(undefined)
+
+  // once you see this shit, you might freak out and you are right. All of them needed because of "update" function trigger by API.
+  // most of the time we need to know what we are doing to treat operations accordingly. Ask for more to me (Ogu), but the answers will make both of us unhappy.
   const isViewerInitialized = ref<boolean>(false)
   const isViewerReadyToLoad = ref<boolean>(false)
   const isViewerObjectsLoaded = ref<boolean>(false)
   const viewerReloadNeeded = ref<boolean>(false)
+  const isLoadingFromFile = ref<boolean>(false)
   const receiveInfo = ref<ReceiveInfo>(undefined)
   const fieldInputState = ref<FieldInputState>({
     rootObjectId: false,
@@ -97,6 +101,8 @@ export const useVisualStore = defineStore('visualStore', () => {
     clearLoadingProgress()
     objectsFromStore.value = objects
     isViewerObjectsLoaded.value = true
+    viewerReloadNeeded.value = false
+    setIsLoadingFromFile(false)
   }
 
   /**
@@ -146,6 +152,8 @@ export const useVisualStore = defineStore('visualStore', () => {
 
   const clearDataInput = () => (dataInput.value = null)
 
+  const setIsLoadingFromFile = (newValue: boolean) => (isLoadingFromFile.value = newValue)
+
   const setViewerReadyToLoad = () => (isViewerReadyToLoad.value = true)
 
   const setViewerReloadNeeded = () => (viewerReloadNeeded.value = true)
@@ -164,6 +172,7 @@ export const useVisualStore = defineStore('visualStore', () => {
     fieldInputState,
     lastLoadedRootObjectId,
     loadingProgress,
+    isLoadingFromFile,
     loadObjectsFromFile,
     setHost,
     setReceiveInfo,
@@ -176,6 +185,7 @@ export const useVisualStore = defineStore('visualStore', () => {
     clearDataInput,
     setViewerReadyToLoad,
     setLoadingProgress,
-    clearLoadingProgress
+    clearLoadingProgress,
+    setIsLoadingFromFile
   }
 })

--- a/src/powerbi-visual/src/utils/matrixViewUtils.ts
+++ b/src/powerbi-visual/src/utils/matrixViewUtils.ts
@@ -241,7 +241,12 @@ export async function processMatrixView(
   console.log('Last laoded root object id', visualStore.lastLoadedRootObjectId)
 
   let objects: object[] = undefined
-  if (visualStore.lastLoadedRootObjectId !== id) {
+
+  if (visualStore.isLoadingFromFile) {
+    console.log('The data is loading from file, skipping the streaming it.')
+  }
+
+  if (visualStore.lastLoadedRootObjectId !== id && !visualStore.isLoadingFromFile) {
     const start = performance.now()
     visualStore.setViewerReadyToLoad()
     visualStore.setLoadingProgress('Loading', null)

--- a/src/powerbi-visual/src/visual.ts
+++ b/src/powerbi-visual/src/visual.ts
@@ -183,6 +183,7 @@ export class Visual implements IVisual {
 
   private tryReadFromFile(objectsFromFile: object[], visualStore) {
     visualStore.setViewerReadyToLoad()
+    visualStore.setIsLoadingFromFile(true) // to block unnecessary streaming data if bg service is running
     setTimeout(() => {
       visualStore.loadObjectsFromFile(objectsFromFile)
       this.isFirstViewerLoad = false


### PR DESCRIPTION
It was loading data twice for saved files if bg service is running