### PR TITLE
fix (data connector): object filtering logic

### DIFF
--- a/src/powerbi-data-connector/speckle/api/GetStructuredData.pqm
+++ b/src/powerbi-data-connector/speckle/api/GetStructuredData.pqm
@@ -4,7 +4,7 @@
         // import the required functions
         GetModel = Extension.LoadFunction("GetModel.pqm"),
         SendToServer = Extension.LoadFunction("SendToServer.pqm"),
-        
+       
         // the logic for importing functions from other files
         Extension.LoadFunction = (fileName as text) =>
             let
@@ -21,26 +21,24 @@
                             Message.Parameters = {fileName, e[Reason], e[Message]},
                             Detail = [File = fileName, Error = e]
                         ],
-        
+       
         // get model info and server data
         modelInfo = GetModel(url),
         rootId = modelInfo[rootObjectId],
-        
+       
         // Get the data from SendToServer - this is already a response from the service
         JsonResponse = SendToServer(url),
-        
+       
         // convert list to table with all columns expanded
         TableFromList = Table.FromList(
-            JsonResponse, 
-            Splitter.SplitByNothing(), 
-            null, 
-            null, 
+            JsonResponse,
+            Splitter.SplitByNothing(),
+            null,
+            null,
             ExtraValues.Error
         ),
-
         // fields to remove from data record
         FieldsToRemove = {"__closure", "totalChildrenCount", "renderMaterialProxies"},
-
         // create the final table with cleaned data records
         FinalTable = Table.FromRecords(
             List.Transform(
@@ -60,8 +58,17 @@
                     ]
             )
         ),
-        
-        // Filter out DataChunks directly by checking speckle_type
-        FilteredTable = Table.SelectRows(FinalTable, each [data][speckle_type] <> "Speckle.Core.Models.DataChunk")
+       
+        // Filtering logic here 
+        // If, model data contains any DataObject -> fetch only data objects
+        // If there are no data objects in the data -> fetch everything but DataChunks
+        HasDataObjects = Table.RowCount(
+            Table.SelectRows(FinalTable, each Text.Contains(Record.FieldOrDefault([data], "speckle_type", ""), "DataObject"))
+        ) > 0,
+
+        FilteredTable = if HasDataObjects then
+            Table.SelectRows(FinalTable, each Text.Contains(Record.FieldOrDefault([data], "speckle_type", ""), "DataObject"))
+        else
+            Table.SelectRows(FinalTable, each Record.FieldOrDefault([data], "speckle_type", "") <> "Speckle.Core.Models.DataChunk")
     in
         FilteredTable

--- a/src/powerbi-data-connector/speckle/api/GetStructuredData.pqm
+++ b/src/powerbi-data-connector/speckle/api/GetStructuredData.pqm
@@ -61,8 +61,7 @@
             )
         ),
         
-        // filter out rows where applicationId is null
-        // we can discuss this further
-        FilteredTable = Table.SelectRows(FinalTable, each Record.FieldOrDefault(([data]), "applicationId", null) <> null)
+        // Filter out DataChunks directly by checking speckle_type
+        FilteredTable = Table.SelectRows(FinalTable, each [data][speckle_type] <> "Speckle.Core.Models.DataChunk")
     in
         FilteredTable


### PR DESCRIPTION
Currently we're filtering the objects by checking their applicationId field. If it doesn't exist or equals to null, we're filtering them out. The initial idea was to remove DataChunks from the query. 

But that caused some issues with models that created by SDK's directly and some connectors like Grasshopper and Blender. For example a model created with specklepy and everything is attached under one collection, receives and empty table at the moment.

![image](https://github.com/user-attachments/assets/685807a5-36c3-4c33-a236-54057df7dda3)

After the change we can receive it as one row.

![image](https://github.com/user-attachments/assets/cb553304-9964-4930-9833-c0f3c4d54256)



Therefore, in this PR, I've changed the filtering logic to directly checking the speckle type. 

![image](https://github.com/user-attachments/assets/54c3ac71-087c-4fc7-b563-2e7b74f51493)

This change also brings some other object types that we were filtering out. Like if I receive data from a model with TeklaObjects, in current logic I only get the Tekla DataObjects.

![Screenshot_1](https://github.com/user-attachments/assets/a3d9963e-2669-457e-aac4-f95ab86f9a2d)

After the changes this PR applies, we'll also get the Mesh objects.

![Screenshot_2](https://github.com/user-attachments/assets/0f3e7fa9-f1d4-4c8f-aff4-530688cc3a4d)

That doesn't cause any harm in the usage, the only potential issue to reach out the Power BI row limit. 

Compared to the problem that some models are completely unusable I'd do this trade-off since going beyond to the row limit is an edge-case in this scenario. (The limit is 1 million rows).

The big model problems are occured mostly in the visual side, we can still do any filtering on that side. Also @oguzhankoral opinion matters on that topic.