### PR TITLE
fix(data connector): reaching the end of the buffer

### DIFF
--- a/src/powerbi-data-connector/Speckle.query.pq
+++ b/src/powerbi-data-connector/Speckle.query.pq
@@ -3,7 +3,7 @@
 // NOTE! for tests, be make sure you put here a model that in private project to make sure all good.
 let
     result = Speckle.GetByUrl(
-        "https://app.speckle.systems/projects/fddfc547ee/models/57d9436086"
+        "https://latest.speckle.systems/projects/126cd4b7bb/models/85c44d39c6"
     )
 in
     result

--- a/src/powerbi-data-connector/Speckle.query.pq
+++ b/src/powerbi-data-connector/Speckle.query.pq
@@ -3,7 +3,7 @@
 // NOTE! for tests, be make sure you put here a model that in private project to make sure all good.
 let
     result = Speckle.GetByUrl(
-        "https://latest.speckle.systems/projects/126cd4b7bb/models/85c44d39c6"
+        "https://app.speckle.systems/projects/fddfc547ee/models/57d9436086"
     )
 in
     result

--- a/src/powerbi-data-connector/speckle/api/GetUser.pqm
+++ b/src/powerbi-data-connector/speckle/api/GetUser.pqm
@@ -26,7 +26,7 @@ in
             parsedUrl = Parser(url),
             server = parsedUrl[baseUrl],
             
-            apiKey = try Extension.CurrentCredential()[Key] otherwise try Extension.CurrentCredential()[access_token] otherwise"" ,
+            apiKey = try Extension.CurrentCredential()[Key] otherwise try Extension.CurrentCredential()[access_token] otherwise "",
             
             query = "query {
                     activeUser {

--- a/src/powerbi-data-connector/speckle/api/GetUser.pqm
+++ b/src/powerbi-data-connector/speckle/api/GetUser.pqm
@@ -26,7 +26,7 @@ in
             parsedUrl = Parser(url),
             server = parsedUrl[baseUrl],
             
-            apiKey = try Extension.CurrentCredential()[Key] otherwise "",
+            apiKey = try Extension.CurrentCredential()[Key] otherwise try Extension.CurrentCredential()[access_token] otherwise"" ,
             
             query = "query {
                     activeUser {
@@ -62,5 +62,5 @@ in
                     ServerName = JsonResponse[data][serverInfo][name],
                     ServerCompany = JsonResponse[data][serverInfo][company],
                     ServerVersion = JsonResponse[data][serverInfo][version],
-                    Token = if apiKey = "" then null else apiKey[access_token]
+                    Token = if apiKey = "" then null else apiKey
                 ]


### PR DESCRIPTION
The source of "We reached end of the buffer" indicates that desktop service is returning an empty or malformed JSON. 

In this case for the private projects, we were not setting the token right. This PR is adding a switch case to check if the token passed through OAuth or directly. For Link Sharable projects, we're setting an empty string as a token.