### PR TITLE
fix (data): exclude raw encodings

### DIFF
--- a/src/powerbi-data-connector/speckle/api/GetStructuredData.pqm
+++ b/src/powerbi-data-connector/speckle/api/GetStructuredData.pqm
@@ -59,16 +59,32 @@
             )
         ),
        
+        // Function to check if a row should be excluded based on speckle type
+        ShouldExcludeRow = (row as record) as logical =>
+            let
+                speckleType = Record.FieldOrDefault(row[data], "speckle_type", "")
+            in
+                speckleType = "Speckle.Core.Models.DataChunk" or 
+                Text.Contains(speckleType, "Objects.Other.RawEncoding"),
+       
         // Filtering logic here 
-        // If, model data contains any DataObject -> fetch only data objects
-        // If there are no data objects in the data -> fetch everything but DataChunks
+        // If model data contains any DataObject -> fetch only data objects (excluding unwanted types)
+        // If there are no data objects in the data -> fetch everything but exclude DataChunks and RawEncoding
         HasDataObjects = Table.RowCount(
-            Table.SelectRows(FinalTable, each Text.Contains(Record.FieldOrDefault([data], "speckle_type", ""), "DataObject"))
+            Table.SelectRows(
+                FinalTable, 
+                each Text.Contains(Record.FieldOrDefault([data], "speckle_type", ""), "DataObject") 
+                     and not ShouldExcludeRow(_)
+            )
         ) > 0,
 
         FilteredTable = if HasDataObjects then
-            Table.SelectRows(FinalTable, each Text.Contains(Record.FieldOrDefault([data], "speckle_type", ""), "DataObject"))
+            Table.SelectRows(
+                FinalTable, 
+                each Text.Contains(Record.FieldOrDefault([data], "speckle_type", ""), "DataObject") 
+                     and not ShouldExcludeRow(_)
+            )
         else
-            Table.SelectRows(FinalTable, each Record.FieldOrDefault([data], "speckle_type", "") <> "Speckle.Core.Models.DataChunk")
+            Table.SelectRows(FinalTable, each not ShouldExcludeRow(_))
     in
         FilteredTable


### PR DESCRIPTION
Adds the logic to exclude `Objects.Other.RawEncoding` when loading data from Speckle. This will help improving the performance and avoid some bad data errors. Related the following ticket:
https://linear.app/speckle/issue/CNX-1652/exclude-3dm-files-from-load-in-power-bi 