### PR TITLE
expand record helper function

### DIFF
--- a/src/powerbi-data-connector/Speckle.pq
+++ b/src/powerbi-data-connector/Speckle.pq
@@ -79,6 +79,7 @@ shared Speckle.Objects.Properties = Value.ReplaceType(
     Speckle.LoadFunction("Objects.Properties.pqm"),
     type function (inputRecord as record, optional filterKeys as list) as record
 );
+
 shared Speckle.Utils.ExpandRecord = Value.ReplaceType(
     Speckle.LoadFunction("Utils.ExpandRecord.pqm"),
     type function (

--- a/src/powerbi-data-connector/Speckle.pq
+++ b/src/powerbi-data-connector/Speckle.pq
@@ -79,6 +79,15 @@ shared Speckle.Objects.Properties = Value.ReplaceType(
     Speckle.LoadFunction("Objects.Properties.pqm"),
     type function (inputRecord as record, optional filterKeys as list) as record
 );
+shared Speckle.Utils.ExpandRecord = Value.ReplaceType(
+    Speckle.LoadFunction("Utils.ExpandRecord.pqm"),
+    type function (
+        table as table,
+        columnName as text,
+        optional FieldNames as list,
+        optional UseCombinedNames as logical
+    ) as table
+);
 
 [DataSource.Kind = "Speckle", Publish="GetByUrl.Publish"]
 shared Speckle.GetByUrl = Value.ReplaceType(

--- a/src/powerbi-data-connector/speckle/api/Utils.ExpandRecord.pqm
+++ b/src/powerbi-data-connector/speckle/api/Utils.ExpandRecord.pqm
@@ -1,0 +1,31 @@
+// Expands a record column in a table, adding new columns for each field in the record.
+// If UseCombinedNames is true, columns are named as ColumnName.FieldName, otherwise just FieldName.
+// If FieldNames is provided (list), only those fields are expanded.
+(table as table, columnName as text, optional FieldNames as list, optional UseCombinedNames as logical) as table =>
+let
+    useCombined = if UseCombinedNames = null then false else UseCombinedNames,
+    // Determine which field names to expand
+    allFieldNames = if FieldNames <> null then FieldNames else List.Distinct(
+        List.Combine(
+            List.Transform(
+                Table.Column(table, columnName),
+                each if _ is record then Record.FieldNames(_) else {}
+            )
+        )
+    ),
+    // Add each field as a new column
+    addColumns = List.Accumulate(
+        allFieldNames,
+        table,
+        (state, field) =>
+            Table.AddColumn(
+                state,
+                if useCombined then columnName & "." & field else field,
+                (row) =>
+                    if Record.HasFields(row, columnName) and Record.Field(row, columnName) is record and Record.HasFields(Record.Field(row, columnName), field)
+                    then Record.Field(Record.Field(row, columnName), field)
+                    else null
+            )
+    )
+in
+    addColumns 


### PR DESCRIPTION
This PR adds a new ExpandRecord helper function to Speckle.Utils namespace. Here's what this function does:

Expands a record column in a table, adding new columns for each field in the record.
- table: The input table.
- columnName: The name of the column containing records to expand.
- FieldNames (optional): List of field names to expand. If null, all fields are expanded.
- UseCombinedNames (optional): If true, new columns are named as ColumnName.FieldName.

This is intended to be used mainly with Speckle.Objects.Properties function, allowing users to quickly expand all or selected parameters into their own columns. But it works with any record object. 