### PR TITLE
object material quantities added

### DIFF
--- a/src/powerbi-data-connector/Speckle.pq
+++ b/src/powerbi-data-connector/Speckle.pq
@@ -96,6 +96,11 @@ shared Speckle.Objects.Collections = Value.ReplaceType(
     type function (inputData as table) as table
 );
 
+shared Speckle.Objects.MaterialQuantities = Value.ReplaceType(
+    Speckle.LoadFunction("Objects.MaterialQuantities.pqm"),
+    type function (objectRecord as record, optional outputAsList as logical) as any
+);
+
 [DataSource.Kind = "Speckle", Publish="GetByUrl.Publish"]
 shared Speckle.GetByUrl = Value.ReplaceType(
     Speckle.LoadFunction("GetByUrl.pqm"),

--- a/src/powerbi-data-connector/speckle/api/Objects.MaterialQuantities.pqm
+++ b/src/powerbi-data-connector/speckle/api/Objects.MaterialQuantities.pqm
@@ -1,0 +1,15 @@
+// Helper function to extract [properties][Material Quantities] and optionally output as list
+(objectRecord as record, optional outputAsList as logical) as any =>
+    let
+        // Ensure outputAsList is logical and defaults to false if not provided
+        OutputAsList = if outputAsList = null then false else outputAsList,
+        // Check if 'properties' and 'Material Quantities' exist
+        HasMaterialQuantities = Record.HasFields(objectRecord, {"properties"}) and Record.HasFields(Record.Field(objectRecord, "properties"), {"Material Quantities"}),
+        MaterialQuantities = if HasMaterialQuantities then Record.Field(Record.Field(objectRecord, "properties"), "Material Quantities") else null,
+        Result = if MaterialQuantities = null then null else
+            if OutputAsList then
+                Record.ToList(MaterialQuantities)
+            else
+                MaterialQuantities
+    in
+        Result


### PR DESCRIPTION
This PR adds a new helper function: Speckle.Objects.MaterialQuantities

This functions allows quick and easy way to extract material quantities. It is intended to be used in "Add Column" flow, so it interacts with individual records, not tables.

**Inputs:**

**objectRecord** (record): The source record.
**outputAsList** (optional logical): If true, returns the result as a list (then user can expand list column themselves); otherwise, as a record (default).

**Returns**:

If the input record contains the "Material Quantities" property, the function returns it either as a record or a list, depending on the outputAsList parameter. If the property is not found, the function returns null.

**Example Usage**

```m
Speckle.Objects.MaterialQuantities(someObjectRecord) // returns the Material Quantities record or null
Speckle.Objects.MaterialQuantities(someObjectRecord, true) // returns the Material Quantities as a list or null. If it's a list
```