### PR TITLE
Helper Function: Federate Models

### DIFF
--- a/src/powerbi-data-connector/Speckle.pq
+++ b/src/powerbi-data-connector/Speckle.pq
@@ -106,6 +106,11 @@ shared Speckle.Objects.MaterialQuantities = Value.ReplaceType(
     type function (objectRecord as record, optional outputAsList as logical) as any
 );
 
+shared Speckle.Models.Federate = Value.ReplaceType(
+    Speckle.LoadFunction("Models.Federate.pqm"),
+    type function (tables as list, optional excludeData as logical) as table
+);
+
 [DataSource.Kind = "Speckle", Publish="GetByUrl.Publish"]
 shared Speckle.GetByUrl = Value.ReplaceType(
     Speckle.LoadFunction("GetByUrl.pqm"),

--- a/src/powerbi-data-connector/speckle/api/Models.Federate.pqm
+++ b/src/powerbi-data-connector/speckle/api/Models.Federate.pqm
@@ -1,0 +1,30 @@
+// function for federating multiple tables by combining them and creating a concatenated Version Object ID
+(tables as list, optional excludeData as logical) as table =>
+let
+    ViewerOnly = if excludeData = null then false else excludeData,
+    
+    // filter columns from each table if excludeData is true
+    ProcessedTables = List.Transform(
+        tables,
+        each
+            if ViewerOnly then 
+                Table.SelectColumns(_, {"Version Object ID", "Object IDs"}, MissingField.Ignore)
+            else 
+                _
+    ),
+    
+    CombinedTable = Table.Combine(ProcessedTables),
+    
+    DistinctVersionObjectIDs = List.Distinct(CombinedTable[Version Object ID]),
+    ConcatenatedVersionObjectIDs = Text.Combine(DistinctVersionObjectIDs, ","),
+    
+    // Replace all Version Object ID values with the concatenated string
+    FederatedTable = Table.ReplaceValue(
+        CombinedTable, 
+        each [Version Object ID], 
+        ConcatenatedVersionObjectIDs, 
+        Replacer.ReplaceText, 
+        {"Version Object ID"}
+    )
+in
+    FederatedTable


### PR DESCRIPTION
## Description
 Adds a new `Speckle.Models.Federate` function to data connector that enables users to combine multiple tables into a single table.

- Accepts a list of tables and combines them into a single table (works with any number of tables)
- Creates a comma-separated concatenated string of all distinct Version Object IDs from the input tables
- Optional excludeData parameter to filter tables to only include "Version Object ID" and "Object IDs" columns

##  This also enables federating models from different projects.
![giphy](https://github.com/user-attachments/assets/03f91c4a-cc7f-4dfe-9d8e-89eba3c603f3)


## Usage
// Basic usage
`Speckle.Models.Federate({structural, architectural, mechanical})`

// exclude data
`Speckle.Models.Federate({structural, architectural}, true)`


https://github.com/user-attachments/assets/85ddf6a4-0dfc-4718-9e5a-ab3406ca5850

