### PR TITLE
fix (visual): reset visual to initial state if all the inputs are removed

### DIFF
--- a/src/powerbi-visual/src/store/visualStore.ts
+++ b/src/powerbi-visual/src/store/visualStore.ts
@@ -437,29 +437,26 @@ export const useVisualStore = defineStore('visualStore', () => {
     host.value.refreshHostData()
   }
 
-  const resetVisualToInitialState = () => {
-    console.log('🔄 Resetting visual to initial state')
+  const resetVisualState = () => {
+    console.log('🔄 Resetting visual state due to missing Version Object ID')
     
-    // Clear data input
+    // Clear all data and state
     dataInput.value = null
+    lastLoadedRootObjectId.value = undefined
+    objectsFromStore.value = undefined
+    receiveInfo.value = undefined
+    commonError.value = undefined
+    loadingProgress.value = undefined
     
-    // Reset viewer states
+    // Reset viewer state
     isViewerReadyToLoad.value = false
     isViewerObjectsLoaded.value = false
     viewerReloadNeeded.value = false
     isLoadingFromFile.value = false
     
-    // Reset filter states
+    // Reset UI state
     isFilterActive.value = false
-    latestColorBy.value = []
-    
-    // Clear cached data
-    objectsFromStore.value = undefined
-    lastLoadedRootObjectId.value = undefined
-    
-    // Clear progress and errors
-    loadingProgress.value = undefined
-    commonError.value = undefined
+    isNavbarHidden.value = false
     
     // Reset field input state
     fieldInputState.value = {
@@ -468,6 +465,8 @@ export const useVisualStore = defineStore('visualStore', () => {
       colorBy: false,
       tooltipData: false
     }
+    
+    console.log('✅ Visual state reset complete')
   }
 
   return {
@@ -541,6 +540,6 @@ export const useVisualStore = defineStore('visualStore', () => {
     resetFilters,
     downloadLatestVersion,
     handleObjectsLoadedComplete,
-    resetVisualToInitialState
+    resetVisualState
   }
 })

--- a/src/powerbi-visual/src/utils/matrixViewUtils.ts
+++ b/src/powerbi-visual/src/utils/matrixViewUtils.ts
@@ -340,13 +340,26 @@ export async function processMatrixView(
   const localMatrixView = matrixView.rows.root.children
   let id = null
 
-  if (hasColorFilter) {
-    id = localMatrixView[0].children[0].values[0].value as unknown as string
-  } else {
-    id = localMatrixView[0].values[0].value as unknown as string
+  // Safely extract the Version Object ID
+  try {
+    if (hasColorFilter) {
+      id = localMatrixView[0]?.children?.[0]?.values?.[0]?.value as unknown as string
+    } else {
+      id = localMatrixView[0]?.values?.[0]?.value as unknown as string
+    }
+  } catch (error) {
+    console.error('❌ Error extracting Version Object ID from matrix view:', error)
+    visualStore.setCommonError('Unable to extract Version Object ID from data. Please check your data configuration.')
+    return
   }
 
-  // const id = localMatrixView[0].values[0].value as unknown as string
+  // Validate that we have a valid ID
+  if (!id || id === null || id === undefined) {
+    console.error('❌ Version Object ID is null or undefined')
+    visualStore.setCommonError('Version Object ID is missing or invalid. Please ensure the field is properly configured.')
+    return
+  }
+
   console.log('🗝️ Root Object Id: ', id)
   console.log('Last laoded root object id', visualStore.lastLoadedRootObjectId)
 

--- a/src/powerbi-visual/src/visual.ts
+++ b/src/powerbi-visual/src/visual.ts
@@ -105,6 +105,13 @@ export class Visual implements IVisual {
       visualStore.setFieldInputState(validationResult)
       console.log('❓Field inputs', validationResult)
 
+      // Check if Version Object ID is missing - if so, reset to initial state
+      if (!validationResult.rootObjectId) {
+        console.log('🚫 Version Object ID is missing - resetting visual to initial state')
+        visualStore.resetVisualState()
+        return
+      }
+
       switch (options.type) {
         case powerbi.VisualUpdateType.Resize:
         case powerbi.VisualUpdateType.ResizeEnd:
@@ -247,14 +254,12 @@ export class Visual implements IVisual {
       console.warn(
         `Incomplete data input. "Viewer Data", "Object IDs" data inputs are mandatory. If your data connector does not output all these columns, please update it.`
       )
-      
-      // Reset visual state when all inputs are removed
-      visualStore.resetVisualToInitialState()
-      
-      // Clear selection handler
-      await this.clear()
-      
-      console.log('🔄 Visual state reset due to empty inputs')
+      visualStore.setFieldInputState({
+        rootObjectId: false,
+        objectIds: false,
+        colorBy: false,
+        tooltipData: false
+      })
       return
     }
   }


### PR DESCRIPTION
This PR implement a new function for resetting visual to its initial state and get triggered if all the inputs of the visual removed. 

More info: https://linear.app/speckle/issue/CNX-2114/3d-visual-doesnt-reset-after-removing-all-inputs