### PR TITLE
Bilal/cnx 2115 configure oauth2 for data gateway usage

### DIFF
--- a/src/powerbi-data-connector/Speckle.pq
+++ b/src/powerbi-data-connector/Speckle.pq
@@ -204,7 +204,7 @@ Speckle = [
                     // Build authorization URL with PKCE parameters
                     authUrl = Text.Combine({server, "authn", "verify", AuthAppId, state}, "/") &
                         "?code_challenge=" & codeChallenge &
-                        "&code_challenge_method=S256"
+                        "&code_challenge_method=plain"
                 in
                     [
                         LoginUri = authUrl,

--- a/src/powerbi-data-connector/Speckle.pq
+++ b/src/powerbi-data-connector/Speckle.pq
@@ -5,22 +5,75 @@ AuthAppId = "spklpwerbi";
 AuthAppSecret = "spklpwerbi";
 
 // PKCE helper functions for enhanced OAuth2 security
+Base64UrlEncode = (binaryData as binary) =>
+    let
+        // Convert binary to base64
+        base64 = Binary.ToText(binaryData, BinaryEncoding.Base64),
+        // Convert to base64url by replacing characters and removing padding
+        base64url = Text.Replace(Text.Replace(Text.Replace(base64, "+", "-"), "/", "_"), "=", "")
+    in
+        base64url;
+
 GeneratePKCEVerifier = () =>
     let
-        // Generate a random code verifier using multiple GUIDs
+        // Generate cryptographically secure random string using allowed characters
+        // RFC 7636: [A-Z] / [a-z] / [0-9] / "-" / "." / "_" / "~"
+        allowedChars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~",
+        
+        // Generate multiple GUIDs to create entropy
         guid1 = Text.Replace(Text.Replace(Text.NewGuid(), "-", ""), "{", ""),
         guid2 = Text.Replace(Text.Replace(Text.NewGuid(), "-", ""), "}", ""),
         guid3 = Text.Replace(Text.Replace(Text.NewGuid(), "-", ""), "{", ""),
         guid4 = Text.Replace(Text.Replace(Text.NewGuid(), "-", ""), "}", ""),
-        verifier = guid1 & guid2 & guid3 & guid4
+        
+        // Combine and convert to allowed characters
+        combined = guid1 & guid2 & guid3 & guid4,
+        
+        // Map hex characters to allowed PKCE characters
+        mapped = Text.Replace(
+            Text.Replace(
+                Text.Replace(
+                    Text.Replace(
+                        Text.Replace(
+                            Text.Replace(combined, "0", "A"),
+                            "1", "B"),
+                        "2", "C"),
+                    "3", "D"),
+                "4", "E"),
+            "5", "F"),
+        
+        // Continue mapping remaining hex chars to allowed chars
+        verifier = Text.Replace(
+            Text.Replace(
+                Text.Replace(
+                    Text.Replace(
+                        Text.Replace(
+                            Text.Replace(
+                                Text.Replace(
+                                    Text.Replace(
+                                        Text.Replace(
+                                            Text.Replace(mapped, "6", "G"),
+                                            "7", "H"),
+                                        "8", "I"),
+                                    "9", "J"),
+                                "a", "K"),
+                            "b", "L"),
+                        "c", "M"),
+                    "d", "N"),
+                "e", "O"),
+            "f", "P"),
+        
+        // Ensure length is between 43-128 characters as per RFC 7636
+        finalVerifier = Text.Start(verifier, 43)
     in
-        Text.Start(verifier, 128);
+        finalVerifier;
 
 GeneratePKCEChallenge = (verifier as text) =>
     let
-        // For Power Query M, we'll use a simpler approach since Crypto functions are limited
-        // This creates a basic challenge - in production, proper SHA256 would be ideal
-        challenge = Text.Replace(Text.Replace(Text.Replace(verifier, "A", "X"), "B", "Y"), "C", "Z")
+        // Create SHA256 hash of the verifier as required by RFC 7636
+        hash = Crypto.CreateHash(CryptoAlgorithm.SHA256, Text.ToBinary(verifier, TextEncoding.Ascii)),
+        // Convert to base64url encoding
+        challenge = Base64UrlEncode(hash)
     in
         challenge;
 
@@ -204,7 +257,7 @@ Speckle = [
                     // Build authorization URL with PKCE parameters
                     authUrl = Text.Combine({server, "authn", "verify", AuthAppId, state}, "/") &
                         "?code_challenge=" & codeChallenge &
-                        "&code_challenge_method=plain"
+                        "&code_challenge_method=S256"
                 in
                     [
                         LoginUri = authUrl,

--- a/src/powerbi-data-connector/Speckle.pq
+++ b/src/powerbi-data-connector/Speckle.pq
@@ -4,6 +4,26 @@ section Speckle;
 AuthAppId = "spklpwerbi";
 AuthAppSecret = "spklpwerbi";
 
+// PKCE helper functions for enhanced OAuth2 security
+GeneratePKCEVerifier = () =>
+    let
+        // Generate a random code verifier using multiple GUIDs
+        guid1 = Text.Replace(Text.Replace(Text.NewGuid(), "-", ""), "{", ""),
+        guid2 = Text.Replace(Text.Replace(Text.NewGuid(), "-", ""), "}", ""),
+        guid3 = Text.Replace(Text.Replace(Text.NewGuid(), "-", ""), "{", ""),
+        guid4 = Text.Replace(Text.Replace(Text.NewGuid(), "-", ""), "}", ""),
+        verifier = guid1 & guid2 & guid3 & guid4
+    in
+        Text.Start(verifier, 128);
+
+GeneratePKCEChallenge = (verifier as text) =>
+    let
+        // For Power Query M, we'll use a simpler approach since Crypto functions are limited
+        // This creates a basic challenge - in production, proper SHA256 would be ideal
+        challenge = Text.Replace(Text.Replace(Text.Replace(verifier, "A", "X"), "B", "Y"), "C", "Z")
+    in
+        challenge;
+
 // function to load `pqm` files - this is essential and must be kept
 shared Speckle.LoadFunction = (fileName as text) =>
     let
@@ -177,14 +197,21 @@ Speckle = [
                 let
                     server = Text.Combine(
                         {Uri.Parts(dataSourcePath)[Scheme], "://", Uri.Parts(dataSourcePath)[Host]}
-                    )
+                    ),
+                    // Generate PKCE parameters for enhanced security
+                    codeVerifier = GeneratePKCEVerifier(),
+                    codeChallenge = GeneratePKCEChallenge(codeVerifier),
+                    // Build authorization URL with PKCE parameters
+                    authUrl = Text.Combine({server, "authn", "verify", AuthAppId, state}, "/") &
+                        "?code_challenge=" & codeChallenge &
+                        "&code_challenge_method=S256"
                 in
                     [
-                        LoginUri = Text.Combine({server, "authn", "verify", AuthAppId, state}, "/"),
+                        LoginUri = authUrl,
                         CallbackUri = "https://oauth.powerbi.com/views/oauthredirect.html",
                         WindowHeight = 800,
                         WindowWidth = 600,
-                        Context = null
+                        Context = [code_verifier = codeVerifier]
                     ],
             FinishLogin = (clientApplication, dataSourcePath, context, callbackUri, state) =>
                 let
@@ -192,20 +219,22 @@ Speckle = [
                         {Uri.Parts(dataSourcePath)[Scheme], "://", Uri.Parts(dataSourcePath)[Host]}
                     ),
                     Parts = Uri.Parts(callbackUri)[Query],
+                    // Extract code verifier from context for PKCE
+                    codeVerifier = if context <> null then context[code_verifier] else null,
+                    // Build token request with PKCE parameters
+                    tokenRequest = [
+                        accessCode = Parts[access_code],
+                        appId = AuthAppId,
+                        appSecret = AuthAppSecret,
+                        challenge = state
+                    ] & (if codeVerifier <> null then [code_verifier = codeVerifier] else []),
                     Source = Web.Contents(
                         Text.Combine({server, "auth", "token"}, "/"),
                         [
                             Headers = [
                                 #"Content-Type" = "application/json"
                             ],
-                            Content = Json.FromValue(
-                                [
-                                    accessCode = Parts[access_code],
-                                    appId = AuthAppId,
-                                    appSecret = AuthAppSecret,
-                                    challenge = state
-                                ]
-                            )
+                            Content = Json.FromValue(tokenRequest)
                         ]
                     ),
                     json = Json.Document(Source)
@@ -221,7 +250,8 @@ Speckle = [
                     server = Text.Combine(
                         {Uri.Parts(dataSourcePath)[Scheme], "://", Uri.Parts(dataSourcePath)[Host]}
                     ),
-                    Source = Web.Contents(
+                    // Enhanced refresh with error handling for gateway compatibility
+                    Source = try Web.Contents(
                         Text.Combine({server, "auth", "token"}, "/"),
                         [
                             Headers = [
@@ -233,17 +263,42 @@ Speckle = [
                                     appId = AuthAppId,
                                     appSecret = AuthAppSecret
                                 ]
-                            )
+                            ),
+                            ManualStatusHandling = {400, 401, 403, 500, 502, 503, 504}
                         ]
-                    ),
-                    json = Json.Document(Source)
+                    ) otherwise null,
+                    
+                    // Check if request was successful
+                    IsSuccess = Source <> null,
+                    
+                    // If successful, parse the response
+                    json = if IsSuccess then
+                        try Json.Document(Source) otherwise null
+                    else
+                        null,
+                    
+                    // Validate the response contains expected fields
+                    IsValidResponse = json <> null and Record.HasFields(json, {"token"}),
+                    
+                    // Return result with enhanced error handling
+                    result = if IsValidResponse then
+                        [
+                            access_token = json[token],
+                            scope = null,
+                            token_type = "bearer",
+                            refresh_token = json[refreshToken]
+                        ]
+                    else
+                        error [
+                            Reason = "TokenRefreshFailed",
+                            Message = "Failed to refresh OAuth token - please re-authenticate",
+                            Detail = [
+                                Server = server,
+                                RefreshToken = if refreshToken = null then "null" else "present"
+                            ]
+                        ]
                 in
-                    [
-                        access_token = json[token],
-                        scope = null,
-                        token_type = "bearer",
-                        refresh_token = json[refreshToken]
-                    ]
+                    result
         ],
         Key = [
             KeyLabel = "Personal Access Token",

--- a/src/powerbi-data-connector/speckle/api/Api.Fetch.pqm
+++ b/src/powerbi-data-connector/speckle/api/Api.Fetch.pqm
@@ -42,16 +42,11 @@
             null,
         
         // Comprehensive error handling
+        // Comprehensive error handling
         result = if not IsHttpSuccess then
             error [
                 Reason = "HttpRequestFailed",
                 Message = "Failed to connect to Speckle server",
-                Detail = [Server = server, StatusCode = StatusCode]
-            ]
-        else if #"JSON" = null then
-            error [
-                Reason = "InvalidJsonResponse",
-                Message = "Server returned invalid JSON response",
                 Detail = [Server = server, StatusCode = StatusCode]
             ]
         else if StatusCode = 401 then
@@ -65,6 +60,12 @@
                 Reason = "AuthorizationFailed", 
                 Message = "Insufficient permissions for this operation",
                 Detail = [Server = server]
+            ]
+        else if #"JSON" = null then
+            error [
+                Reason = "InvalidJsonResponse",
+                Message = "Server returned invalid JSON response",
+                Detail = [Server = server, StatusCode = StatusCode]
             ]
         else if Record.HasFields(#"JSON", {"errors"}) then
             error [

--- a/src/powerbi-data-connector/speckle/api/Api.Fetch.pqm
+++ b/src/powerbi-data-connector/speckle/api/Api.Fetch.pqm
@@ -1,6 +1,8 @@
 (server as text, optional query as text, optional variables as record) as record =>
     let
-        apiKey = try Extension.CurrentCredential()[Key] otherwise null,
+        // Enhanced credential retrieval with OAuth2 support
+        apiKey = try Extension.CurrentCredential()[Key] otherwise try Extension.CurrentCredential()[access_token] otherwise null,
+        
         defaultQuery = "query {
                 activeUser {
                     email 
@@ -12,7 +14,9 @@
                     version
                 }
             }",
-        Source = Web.Contents(
+        
+        // Enhanced API call with comprehensive error handling
+        Source = try Web.Contents(
             Text.Combine({server, "graphql"}, "/"),
             [
                 Headers = [
@@ -20,14 +24,55 @@
                     #"Content-Type" = "application/json",
                     #"Authorization" = if apiKey = null then "" else Text.Format("Bearer #{0}", {apiKey})
                 ],
-                ManualStatusHandling = {400},
+                ManualStatusHandling = {400, 401, 403, 404, 500, 502, 503, 504},
                 Content = Json.FromValue([query = Text.From(query ?? defaultQuery), variables = variables])
             ]
-        ),
-        #"JSON" = Json.Document(Source)
-    in
-        // Check if response contains errors, if so, return first error.
-        if Record.HasFields(#"JSON", {"errors"}) then
-            error #"JSON"[errors]{0}[message]
+        ) otherwise null,
+        
+        // Check if the HTTP request was successful
+        IsHttpSuccess = Source <> null,
+        
+        // Get HTTP status code for detailed error handling
+        StatusCode = if IsHttpSuccess then Value.Metadata(Source)[Response.Status] else null,
+        
+        // Parse JSON response if HTTP request was successful
+        #"JSON" = if IsHttpSuccess then
+            try Json.Document(Source) otherwise null
+        else
+            null,
+        
+        // Comprehensive error handling
+        result = if not IsHttpSuccess then
+            error [
+                Reason = "HttpRequestFailed",
+                Message = "Failed to connect to Speckle server",
+                Detail = [Server = server, StatusCode = StatusCode]
+            ]
+        else if #"JSON" = null then
+            error [
+                Reason = "InvalidJsonResponse",
+                Message = "Server returned invalid JSON response",
+                Detail = [Server = server, StatusCode = StatusCode]
+            ]
+        else if StatusCode = 401 then
+            error [
+                Reason = "AuthenticationFailed",
+                Message = "Invalid or expired authentication token",
+                Detail = [Server = server, HasToken = apiKey <> null]
+            ]
+        else if StatusCode = 403 then
+            error [
+                Reason = "AuthorizationFailed", 
+                Message = "Insufficient permissions for this operation",
+                Detail = [Server = server]
+            ]
+        else if Record.HasFields(#"JSON", {"errors"}) then
+            error [
+                Reason = "GraphQLError",
+                Message = #"JSON"[errors]{0}[message],
+                Detail = [Server = server, Errors = #"JSON"[errors]]
+            ]
         else
             #"JSON"[data]
+    in
+        result


### PR DESCRIPTION
This PR implements OAuth2 authentication with PKCE (Proof Key for Code Exchange) security for the Speckle Power BI data connector to support Data Gateway usage.

- Added full OAuth2 authentication flow with proper token exchange and refresh mechanisms
- Implemented SHA256-based PKCE challenge/verifier generation for enhanced security per RFC 7636
- Configured OAuth2 flow specifically for Power BI Data Gateway deployment requirements

## Video
# TODO

## Testing

- [ ] OAuth2 flow works in Power BI Desktop
- [ ] Data Gateway deployment works
- [ ] Authentication persists across gateway restarts