### PR TITLE
fix (visual): disable selection of ghosted objects

### DIFF
--- a/src/powerbi-visual/src/extensions/FilteredSelectionExtension.ts
+++ b/src/powerbi-visual/src/extensions/FilteredSelectionExtension.ts
@@ -1,0 +1,149 @@
+import {
+  CameraController,
+  FilteringExtension,
+  NodeRenderView,
+  SelectionEvent,
+  SelectionExtension,
+  TreeNode,
+  ObjectLayers,
+  IViewer,
+  ExtendedIntersection
+} from '@speckle/viewer'
+import { Vector2, Vector3 } from 'three'
+
+export enum FilteredSelectionEvent {
+  FilteredObjectClicked = 'filtered-object-clicked'
+}
+
+export interface FilteredSelectionEventPayload {
+  [FilteredSelectionEvent.FilteredObjectClicked]: SelectionEvent | null
+}
+
+export class FilteredSelectionExtension extends SelectionExtension {
+  // We're adding the Filtering Extension
+  public get inject(): Array<new (viewer: IViewer, ...args: any[]) => any> {
+    return [...super.inject, FilteringExtension]
+  }
+
+  public constructor(
+    viewer: IViewer,
+    protected cameraProvider: CameraController,
+    protected filtering: FilteringExtension
+  ) {
+    super(viewer, cameraProvider)
+  }
+
+  public on<T extends FilteredSelectionEvent>(
+    eventType: T,
+    listener: (arg: FilteredSelectionEventPayload[T]) => void
+  ): void {
+    super.on(eventType, listener)
+  }
+
+  protected isVisibleForSelection(id: string): boolean
+  protected isVisibleForSelection(rv: NodeRenderView): boolean
+  protected isVisibleForSelection(input: string | NodeRenderView): boolean {
+    if (input instanceof NodeRenderView) return this.isVisibleForSelectionRv(input)
+    else if (typeof input === 'string') return this.isVisibleForSelectionId(input)
+    return false
+  }
+
+  protected isVisibleForSelectionId(id: string): boolean {
+    // The current filtering state
+    const filteringState = this.filtering.filteringState
+
+    // If there are no isolated objects, all objects are visible for selection
+    if (!filteringState.isolatedObjects || filteringState.isolatedObjects.length === 0) {
+      return true
+    }
+
+    // If there are isolated objects, only those objects are visible for selection
+    return filteringState.isolatedObjects.includes(id)
+  }
+
+  protected isVisibleForSelectionRv(rv: NodeRenderView): boolean {
+    // The current filtering state
+    const filteringState = this.filtering.filteringState
+
+    // If there are no isolated objects, all objects are visible for selection
+    if (!filteringState.isolatedObjects || filteringState.isolatedObjects.length === 0) {
+      return true
+    }
+
+    // Check if this render view belongs to any of the isolated objects
+    for (let k = 0; k < filteringState.isolatedObjects.length; k++) {
+      const rvs = this.viewer
+        .getWorldTree()
+        .getRenderTree()
+        .getRenderViewsForNodeId(filteringState.isolatedObjects[k])
+      if (rvs.includes(rv)) return true
+    }
+    return false
+  }
+
+  protected onObjectClicked(selection: SelectionEvent | null) {
+    if (!selection) {
+      super.onObjectClicked(selection)
+      return
+    }
+
+    const filteredHits = []
+    const filteredSelection = selection
+      ? {
+          event: selection.event,
+          hits: filteredHits,
+          multiple: selection.multiple
+        }
+      : null
+
+    if (filteredSelection) {
+      for (const hit of selection.hits) {
+        if (this.isVisibleForSelection(hit.node.model.id)) {
+          filteredHits.push(hit)
+        }
+      }
+    }
+
+    // Call base class with the filtered selection
+    if (filteredSelection && filteredSelection.hits.length) {
+      super.onObjectClicked(filteredSelection)
+      this.emit(FilteredSelectionEvent.FilteredObjectClicked, filteredSelection)
+    } else {
+      // If no valid hits, treat as empty selection
+      super.onObjectClicked(null)
+    }
+  }
+
+  protected onPointerMove(e: Vector2 & { event: Event }) {
+    if (!this._enabled) return
+    const camera = this.viewer.getRenderer().renderingCamera
+    if (!camera) return
+
+    if (!this.options.hoverMaterialData) return
+    const result =
+      (this.viewer
+        .getRenderer()
+        .intersections.intersect(
+          this.viewer.getRenderer().scene,
+          camera,
+          e,
+          [
+            ObjectLayers.STREAM_CONTENT_MESH,
+            ObjectLayers.STREAM_CONTENT_POINT,
+            ObjectLayers.STREAM_CONTENT_LINE,
+            ObjectLayers.STREAM_CONTENT_TEXT
+          ],
+          true,
+          this.viewer.getRenderer().clippingVolume
+        ) as ExtendedIntersection[]) || []
+
+    let rv = null
+    for (let k = 0; k < result.length; k++) {
+      rv = this.viewer.getRenderer().renderViewFromIntersection(result[k])
+      if (this.isVisibleForSelection(rv)) break
+      else rv = null
+    }
+
+    this.applyHover(rv)
+  }
+}

--- a/src/powerbi-visual/src/extensions/FilteredSelectionExtension.ts
+++ b/src/powerbi-visual/src/extensions/FilteredSelectionExtension.ts
@@ -82,7 +82,10 @@ export class FilteredSelectionExtension extends SelectionExtension {
   }
 
   protected onObjectClicked(selection: SelectionEvent | null) {
+    console.log('🎯 FilteredSelectionExtension.onObjectClicked called with:', selection)
+    
     if (!selection) {
+      console.log('🎯 No selection, calling super with null')
       super.onObjectClicked(selection)
       return
     }
@@ -98,11 +101,14 @@ export class FilteredSelectionExtension extends SelectionExtension {
 
     if (filteredSelection) {
       for (const hit of selection.hits) {
+        console.log('🎯 Checking hit:', hit.node.model.id, 'isVisible:', this.isVisibleForSelection(hit.node.model.id))
         if (this.isVisibleForSelection(hit.node.model.id)) {
           filteredHits.push(hit)
         }
       }
     }
+
+    console.log('🎯 Filtered hits:', filteredHits.length)
 
     // Call base class with the filtered selection
     if (filteredSelection && filteredSelection.hits.length) {

--- a/src/powerbi-visual/src/plugins/viewer.ts
+++ b/src/powerbi-visual/src/plugins/viewer.ts
@@ -13,14 +13,14 @@ import {
   SelectionExtension,
   FilteringExtension,
   UpdateFlags,
-  ViewerEvent,
-  ObjectLayers
+  ViewerEvent
 } from '@speckle/viewer'
+import { FilteredSelectionExtension } from '@src/extensions/FilteredSelectionExtension'
 import { SpeckleObjectsOfflineLoader } from '@src/laoder/SpeckleObjectsOfflineLoader'
 import { useVisualStore } from '@src/store/visualStore'
 import { Tracker } from '@src/utils/mixpanel'
 import { createNanoEvents, Emitter } from 'nanoevents'
-import { Vector3, Vector2 } from 'three'
+import { Vector3 } from 'three'
 
 export interface IViewer {
   /**
@@ -66,7 +66,7 @@ export class ViewerHandler {
   public viewer: Viewer
   public cameraControls: CameraController
   public filtering: FilteringExtension
-  public selection: SelectionExtension
+  public selection: FilteredSelectionExtension
   private filteringState: FilteringState
 
   constructor() {
@@ -92,10 +92,7 @@ export class ViewerHandler {
     this.viewer = await createViewer(parent)
     this.cameraControls = this.viewer.getExtension(CameraController)
     this.filtering = this.viewer.getExtension(FilteringExtension)
-    this.selection = this.viewer.getExtension(SelectionExtension)
-
-    // Override the SelectionExtension's click handler to apply our filtering
-    this.viewer.on(ViewerEvent.ObjectClicked, this.onViewerObjectClicked.bind(this))
+    this.selection = this.viewer.getExtension(FilteredSelectionExtension)
 
     const store = useVisualStore()
     if (store.isOrthoProjection) {
@@ -165,7 +162,7 @@ export class ViewerHandler {
   }
 
   public resetFilter = (objectIds: string[], ghost: boolean, zoom: boolean = true) => {
-    console.log('🔗 Handling resetFilter inside ViewerHandler')
+    console.log('🔗 Handling filterSelection inside ViewerHandler')
     if (objectIds) {
       this.isolateObjects(objectIds, ghost)
       if (zoom) {
@@ -203,96 +200,22 @@ export class ViewerHandler {
   }
 
   public intersect = (coords: { x: number; y: number }) => {
-    const camera = this.viewer.getRenderer().renderingCamera
-    if (!camera) {
-      this.selection.clearSelection()
-      return
-    }
-
-    // Convert screen coordinates to NDC
     const point = this.viewer.Utils.screenToNDC(coords.x, coords.y)
 
-    // Use the renderer's intersection method directly to get detailed results
-    const results = this.viewer.getRenderer().intersections.intersect(
-      this.viewer.getRenderer().scene,
-      camera,
-      new Vector2(point.x, point.y),
-      [
-        ObjectLayers.STREAM_CONTENT_MESH,
-        ObjectLayers.STREAM_CONTENT_POINT,
-        ObjectLayers.STREAM_CONTENT_LINE,
-        ObjectLayers.STREAM_CONTENT_TEXT
-      ],
-      true,
-      this.viewer.getRenderer().clippingVolume
-    )
-    
-    if (!results || results.length === 0) {
+    const intQuery: IntersectionQuery = {
+      operation: 'Pick',
+      point
+    }
+
+    const res = this.viewer.query(intQuery)
+
+    if (!res) {
       this.selection.clearSelection()
       return
     }
-
-    // Filter out hidden and ghosted objects
-    const filteredResults = results.filter((intersection) => {
-      if (intersection.batchObject) {
-        try {
-          // Cast to the proper type that has getBatchObjectMaterial method
-          const material = (intersection.object as any).getBatchObjectMaterial(intersection.batchObject)
-          // Simple approach: only keep materials that are visible
-          // Hidden and ghosted materials should have visible: false
-          return material && material.visible
-        } catch (error) {
-          return true
-        }
-      }
-      return true
-    })
-
-    if (filteredResults.length === 0) {
-      this.selection.clearSelection()
-      return
-    }
-
-    // Convert the filtered result to the format expected by the rest of the code
-    const hits = this.viewer.getRenderer().queryHits(filteredResults)
-    
-    if (!hits || hits.length === 0) {
-      this.selection.clearSelection()
-      return
-    }
-
-    // Additional filtering based on isolation state
-    let validHits = hits
-    
-    // Use extension filtering state as fallback if local state is out of sync
-    const currentFilteringState = this.filteringState || this.filtering?.filteringState
-    const isolatedObjects = currentFilteringState?.isolatedObjects || []
-    
-    if (isolatedObjects && isolatedObjects.length > 0) {
-      validHits = hits.filter(hit => {
-        return isolatedObjects.includes(hit.node.model.id)
-      })
-    }
-
-    if (validHits.length === 0) {
-      this.selection.clearSelection()
-      return
-    }
-
-    // Use the first valid hit
-    const hit = validHits[0]
-    
     return {
-      hit: {
-        guid: hit.node.model.id,
-        object: hit.node.model.raw,
-        point: hit.point
-      },
-      objects: validHits.map(h => ({
-        guid: h.node.model.id,
-        object: h.node.model.raw,
-        point: h.point
-      }))
+      hit: this.pickViewableHit(res.objects),
+      objects: res.objects
     }
   }
 
@@ -342,7 +265,7 @@ export class ViewerHandler {
       )
       this.cameraControls.setCameraView({ position, target }, true)
     }
-    
+
     // Emit objects loaded event to trigger update
     this.emit('objectsLoaded')
   }
@@ -364,54 +287,14 @@ export class ViewerHandler {
     // Are there any objects isolated?
     const hasIsolatedObjects =
       !!filteringState.isolatedObjects && filteringState.isolatedObjects.length !== 0
-    // Are there any objects hidden?
-    const hasHiddenObjects =
-      !!filteringState.hiddenObjects && filteringState.hiddenObjects.length !== 0
-    // No isolated or hidden objects? Return the first hit
-    if (hasIsolatedObjects && !hasHiddenObjects) {
-      return hits.find((h) => filteringState.isolatedObjects.includes(h.guid))
+
+    // If there are isolated objects, only allow selection of isolated objects
+    if (hasIsolatedObjects) {
+      return hits.find((h) => filteringState.isolatedObjects.includes(h.guid)) || null
     }
 
-    for (let k = 0; k < hits.length; k++) {
-      /** Return the first one that's not hidden or isolated. */
-      if (
-        hasIsolatedObjects &&
-        filteringState.isolatedObjects?.includes(hits[k].guid) &&
-        hasHiddenObjects &&
-        filteringState.hiddenObjects?.includes(hits[k].guid)
-      )
-        return hits[k]
-    }
-  }
-
-  public onViewerObjectClicked = (selectionEvent: any) => {
-    if (!selectionEvent || !selectionEvent.hits || selectionEvent.hits.length === 0) {
-      // No selection or no hits - let the SelectionExtension handle it normally
-      return
-    }
-
-    // Apply the same isolation filtering as in our intersect method
-    const currentFilteringState = this.filteringState || this.filtering?.filteringState
-    const isolatedObjects = currentFilteringState?.isolatedObjects || []
-
-    if (isolatedObjects && isolatedObjects.length > 0) {
-      // Filter hits to only include isolated objects
-      const filteredHits = selectionEvent.hits.filter(hit => {
-        return isolatedObjects.includes(hit.node.model.id)
-      })
-
-      if (filteredHits.length === 0) {
-        // Block the selection by calling the SelectionExtension with null
-        this.selection.clearSelection()
-        return
-      }
-
-      // Update the selection event with filtered hits
-      selectionEvent.hits = filteredHits
-    }
-
-    // Let the original SelectionExtension handle the (potentially filtered) selection event
-    // We don't need to call anything here as the SelectionExtension will process it next
+    // If no isolated objects, return the first hit (all objects are selectable)
+    return hits[0] || null
   }
 
   public dispose() {
@@ -429,7 +312,7 @@ const createViewer = async (parent: HTMLElement): Promise<Viewer> => {
   await viewer.init()
 
   viewer.createExtension(HybridCameraController) // camera controller
-  viewer.createExtension(SelectionExtension) // selection helper
+  viewer.createExtension(FilteredSelectionExtension) // filtered selection helper
   // viewer.createExtension(SectionTool) // section tool, possibly not needed for now?
   // viewer.createExtension(SectionOutlines) // section tool, possibly not needed for now?
   // viewer.createExtension(MeasurementsExtension) // measurements, possibly not needed for now?

--- a/src/powerbi-visual/src/plugins/viewer.ts
+++ b/src/powerbi-visual/src/plugins/viewer.ts
@@ -1,7 +1,6 @@
 import {
   DefaultViewerParams,
   FilteringState,
-  IntersectionQuery,
   CameraController,
   CanonicalView,
   ViewModes,
@@ -13,9 +12,10 @@ import {
   SelectionExtension,
   FilteringExtension,
   UpdateFlags,
-  ViewerEvent
+  ViewerEvent,
+  SelectionEvent
 } from '@speckle/viewer'
-import { FilteredSelectionExtension } from '@src/extensions/FilteredSelectionExtension'
+import { FilteredSelectionExtension, FilteredSelectionEvent } from '@src/extensions/FilteredSelectionExtension'
 import { SpeckleObjectsOfflineLoader } from '@src/laoder/SpeckleObjectsOfflineLoader'
 import { useVisualStore } from '@src/store/visualStore'
 import { Tracker } from '@src/utils/mixpanel'
@@ -54,6 +54,7 @@ export interface IViewerEvents {
   toggleGhostHidden: (ghost: boolean) => void
   loadObjects: (objects: object[]) => void
   objectsLoaded: () => void
+  objectClicked: (hit: Hit | null, isMultiSelect: boolean, mouseEvent?: PointerEvent) => void
 }
 
 export type ColorBy = {
@@ -102,6 +103,14 @@ export class ViewerHandler {
     this.viewer.on(ViewerEvent.LoadComplete, (arg: string) => {
       store.clearLoadingProgress()
     })
+
+    // Set up event listener for viewer's built-in object clicked events
+    this.viewer.on(ViewerEvent.ObjectClicked, (selection: SelectionEvent | null) => {
+      console.log('🎯 Viewer ObjectClicked event received:', selection)
+    })
+
+    // Set up event listener for filtered selection events
+    this.selection.on(FilteredSelectionEvent.FilteredObjectClicked, this.handleFilteredSelection)
   }
 
   emit<E extends keyof IViewerEvents>(event: E, ...payload: Parameters<IViewerEvents[E]>): void {
@@ -199,25 +208,7 @@ export class ViewerHandler {
     }
   }
 
-  public intersect = (coords: { x: number; y: number }) => {
-    const point = this.viewer.Utils.screenToNDC(coords.x, coords.y)
 
-    const intQuery: IntersectionQuery = {
-      operation: 'Pick',
-      point
-    }
-
-    const res = this.viewer.query(intQuery)
-
-    if (!res) {
-      this.selection.clearSelection()
-      return
-    }
-    return {
-      hit: this.pickViewableHit(res.objects),
-      objects: res.objects
-    }
-  }
 
   public loadObjects = async (modelObjects: object[][]) => {
     await this.viewer.unloadAll()
@@ -281,21 +272,34 @@ export class ViewerHandler {
     store.handleObjectsLoadedComplete()
   }
 
-  private pickViewableHit(hits: Hit[]): Hit | null {
-    // The current filtering state
-    const filteringState = this.filtering.filteringState
-    // Are there any objects isolated?
-    const hasIsolatedObjects =
-      !!filteringState.isolatedObjects && filteringState.isolatedObjects.length !== 0
-
-    // If there are isolated objects, only allow selection of isolated objects
-    if (hasIsolatedObjects) {
-      return hits.find((h) => filteringState.isolatedObjects.includes(h.guid)) || null
+  private handleFilteredSelection = (selection: SelectionEvent | null) => {
+    console.log('🎯 Filtered selection event received:', selection)
+    
+    let hit: Hit | null = null
+    let isMultiSelect = false
+    let mouseEvent: PointerEvent | undefined = undefined
+    
+    if (selection && selection.hits.length > 0) {
+      // Convert the first hit to the Hit format expected by ViewerWrapper
+      const firstHit = selection.hits[0]
+      hit = {
+        guid: firstHit.node.model.id,
+        object: firstHit.node.model.raw,
+        point: {
+          x: firstHit.point.x,
+          y: firstHit.point.y,
+          z: firstHit.point.z
+        }
+      }
+      isMultiSelect = selection.multiple
+      mouseEvent = selection.event
     }
-
-    // If no isolated objects, return the first hit (all objects are selectable)
-    return hits[0] || null
+    
+    // Emit the objectClicked event for ViewerWrapper to handle
+    this.emit('objectClicked', hit, isMultiSelect, mouseEvent)
   }
+
+
 
   public dispose() {
     this.viewer.getExtension(CameraController).dispose()
@@ -312,11 +316,11 @@ const createViewer = async (parent: HTMLElement): Promise<Viewer> => {
   await viewer.init()
 
   viewer.createExtension(HybridCameraController) // camera controller
-  viewer.createExtension(FilteredSelectionExtension) // filtered selection helper
+  viewer.createExtension(FilteringExtension) // filtering - must be created before FilteredSelectionExtension
+  viewer.createExtension(FilteredSelectionExtension) // filtered selection helper - depends on FilteringExtension
   // viewer.createExtension(SectionTool) // section tool, possibly not needed for now?
   // viewer.createExtension(SectionOutlines) // section tool, possibly not needed for now?
   // viewer.createExtension(MeasurementsExtension) // measurements, possibly not needed for now?
-  viewer.createExtension(FilteringExtension) // filtering
   viewer.createExtension(ViewModes) // view modes
 
   console.log('🎥 Viewer is created!')

--- a/src/powerbi-visual/src/utils/viewerUtils.ts
+++ b/src/powerbi-visual/src/utils/viewerUtils.ts
@@ -1,4 +1,3 @@
-import { FilteringState } from '@speckle/viewer'
 import { OrthographicCamera, PerspectiveCamera } from 'three'
 
 export function projectToScreen(cam: OrthographicCamera | PerspectiveCamera, loc) {
@@ -16,17 +15,7 @@ export interface Hit {
   object?: Record<string, unknown>
   point: { x: number; y: number; z: number }
 }
-export function pickViewableHit(hits: Hit[], state: FilteringState): Hit | null {
-  let hit = null
-  if (state.isolatedObjects) {
-    // Find the first hit contained in the isolated objects
-    hit = hits.find((hit) => {
-      const hitId = hit.object.id as string
-      return state.isolatedObjects.includes(hitId)
-    })
-  }
-  return hit
-}
+
 
 export const createViewerContainerDiv = (parent: HTMLElement) => {
   const container = parent.appendChild(document.createElement('div'))


### PR DESCRIPTION
## Problem
Users were still able to click and select ghosted/hidden objects in the viewer which was causing a bad experience when navigating inside the visual.

## Solution
- Added material visibility filtering
- Implemented isolation state checking
- Only allows selection of objects in the isolatedObjects array
- Let selection extension handle the rest

