### PR TITLE
Parameter Group as suffix

### DIFF
--- a/src/powerbi-data-connector/Speckle.pq
+++ b/src/powerbi-data-connector/Speckle.pq
@@ -150,7 +150,7 @@ shared Speckle.GetWorkspace = Value.ReplaceType(
 
 shared Speckle.Objects.Properties = Value.ReplaceType(
     Speckle.LoadFunction("Objects.Properties.pqm"),
-    type function (inputRecord as record, optional filterKeys as list) as record
+    type function (inputRecord as any, optional targetFields as list, optional parentPath as text, optional existingFields as list) as record
 );
 
 

--- a/src/powerbi-data-connector/Speckle.pq
+++ b/src/powerbi-data-connector/Speckle.pq
@@ -150,7 +150,7 @@ shared Speckle.GetWorkspace = Value.ReplaceType(
 
 shared Speckle.Objects.Properties = Value.ReplaceType(
     Speckle.LoadFunction("Objects.Properties.pqm"),
-    type function (inputRecord as any, optional targetFields as list, optional parentPath as text, optional existingFields as list) as record
+    type function (inputRecord as any, optional filterKeys as list, optional parentPath as text, optional existingFields as list) as record
 );
 
 

--- a/src/powerbi-data-connector/speckle/api/Objects.Properties.pqm
+++ b/src/powerbi-data-connector/speckle/api/Objects.Properties.pqm
@@ -156,9 +156,14 @@ let
                                                 else
                                                     let
                                                         // Call the function through the passed reference
+                                                        // IMPORTANT: Pass the current state's existing fields list
                                                         flattened = flattenFn(flattenFn, fieldValue, currentTargetFields, newPath, state[ExistingFieldsList]),
+                                                        // Get all field names from the flattened result
+                                                        flattenedFieldNames = Record.FieldNames(flattened),
+                                                        // Merge the flattened record with the current state
                                                         combinedRecord = flattened & state[FlattenedRecord],
-                                                        allFieldNames = Record.FieldNames(combinedRecord)
+                                                        // Update the existing fields list with ALL fields from both records
+                                                        allFieldNames = List.Distinct(state[ExistingFieldsList] & flattenedFieldNames)
                                                     in
                                                         [FlattenedRecord = combinedRecord, ExistingFieldsList = allFieldNames]
                                             in
@@ -189,8 +194,12 @@ let
                                                                             let
                                                                                 // Call the function through the passed reference
                                                                                 flattened = flattenFn(flattenFn, listItem, currentTargetFields, listPath, listState[ExistingFieldsList]),
+                                                                                // Get all field names from the flattened result
+                                                                                flattenedFieldNames = Record.FieldNames(flattened),
+                                                                                // Merge the flattened record with the current state
                                                                                 combinedRecord = flattened & listState[FlattenedRecord],
-                                                                                allFieldNames = Record.FieldNames(combinedRecord)
+                                                                                // Update the existing fields list with ALL fields
+                                                                                allFieldNames = List.Distinct(listState[ExistingFieldsList] & flattenedFieldNames)
                                                                             in
                                                                                 [FlattenedRecord = combinedRecord, ExistingFieldsList = allFieldNames]
                                                                     in

--- a/src/powerbi-data-connector/speckle/api/Objects.Properties.pqm
+++ b/src/powerbi-data-connector/speckle/api/Objects.Properties.pqm
@@ -1,5 +1,5 @@
 // function for extracting and flattening properties from Speckle objects
-(inputRecord as any, optional targetFields as list, optional parentPath as text, optional existingFields as list) as record =>
+(inputRecord as any, optional filterKeys as list, optional parentPath as text, optional existingFields as list) as record =>
 let
     // Define excluded paths
     ExcludedPaths = {
@@ -66,7 +66,7 @@ let
     FlattenRecordImpl = (
         flattenFn as function,
         inputRecord as any, 
-        targetFields as nullable list, 
+        filterKeys as nullable list, 
         parentPathParam as nullable text, 
         existingFieldsParam as nullable list
     ) as record =>
@@ -74,7 +74,7 @@ let
             // Ensure non-null values for internal use
             currentParentPath = if parentPathParam = null then "" else parentPathParam,
             currentExistingFields = if existingFieldsParam = null then {} else existingFieldsParam,
-            currentTargetFields = targetFields,
+            currentfilterKeys = filterKeys,
             
             // Check if record has "properties" field and use it instead of the root record
             recordToProcess = if inputRecord = null then 
@@ -86,8 +86,8 @@ let
             
             // Helper function to check if a field should be included
             ShouldIncludeField = (fieldName as text) as logical =>
-                if currentTargetFields = null then true
-                else List.Contains(currentTargetFields, fieldName),
+                if currentfilterKeys = null then true
+                else List.Contains(currentfilterKeys, fieldName),
             
             // Handle different input types
             result = if recordToProcess = null then
@@ -157,7 +157,7 @@ let
                                                     let
                                                         // Call the function through the passed reference
                                                         // IMPORTANT: Pass the current state's existing fields list
-                                                        flattened = flattenFn(flattenFn, fieldValue, currentTargetFields, newPath, state[ExistingFieldsList]),
+                                                        flattened = flattenFn(flattenFn, fieldValue, currentfilterKeys, newPath, state[ExistingFieldsList]),
                                                         // Get all field names from the flattened result
                                                         flattenedFieldNames = Record.FieldNames(flattened),
                                                         // Merge the flattened record with the current state
@@ -193,7 +193,7 @@ let
                                                                         else
                                                                             let
                                                                                 // Call the function through the passed reference
-                                                                                flattened = flattenFn(flattenFn, listItem, currentTargetFields, listPath, listState[ExistingFieldsList]),
+                                                                                flattened = flattenFn(flattenFn, listItem, currentfilterKeys, listPath, listState[ExistingFieldsList]),
                                                                                 // Get all field names from the flattened result
                                                                                 flattenedFieldNames = Record.FieldNames(flattened),
                                                                                 // Merge the flattened record with the current state
@@ -252,6 +252,6 @@ let
             result,
     
     // Call the implementation with self-reference
-    result = FlattenRecordImpl(FlattenRecordImpl, inputRecord, targetFields, parentPath, existingFields)
+    result = FlattenRecordImpl(FlattenRecordImpl, inputRecord, filterKeys, parentPath, existingFields)
 in
     result

--- a/src/powerbi-data-connector/speckle/api/Objects.Properties.pqm
+++ b/src/powerbi-data-connector/speckle/api/Objects.Properties.pqm
@@ -1,196 +1,248 @@
 // function for extracting and flattening properties from Speckle objects
-(inputRecord as record, optional filterKeys as list) as record =>
+(inputRecord as any, optional targetFields as list, optional parentPath as text, optional existingFields as list) as record =>
 let
-    // auto-extract properties if the input has a "properties" field
-    ActualInput = if Record.HasFields(inputRecord, {"properties"}) then 
-        inputRecord[properties] 
-    else 
-        inputRecord,
-    
-    // helper function to check if a key should be included
-    ShouldIncludeKey = (keyName as text) as logical =>
-        if filterKeys = null then 
-            true 
-        else 
-            List.Contains(filterKeys, keyName),
-    
-    // define excluded paths
+    // Define excluded paths
     ExcludedPaths = {
         "Composite Structure",
         "Material Quantities", 
         "Parameters.Type Parameters.Structure"
     },
     
-    IsExcludedPath = (path as text) as logical =>
-        List.AnyTrue(
-            List.Transform(
-                ExcludedPaths,
-                (excludedPath) => Text.StartsWith(path, excludedPath)
-            )
-        ),
+    // Helper function to check if a path should be excluded
+    IsPathExcluded = (currentPath as text) as logical =>
+        List.AnyTrue(List.Transform(ExcludedPaths, each Text.Contains(currentPath, _))),
     
-    // helper function to handle duplicate keys by adding suffixes
-    AddUniqueKey = (existingRecord as record, newKey as text, newValue as any) as record =>
+    // Helper function to resolve naming conflicts
+    ResolveFieldName = (fieldName as text, parentPathParam as nullable text, existingFieldsParam as nullable list) as text =>
         let
-            originalKey = newKey,
-            counter = 1,
+            // Ensure we have valid inputs
+            parentPath = if parentPathParam = null then "" else parentPathParam,
+            existingFields = if existingFieldsParam = null then {} else existingFieldsParam,
             
-            // find a unique key by adding suffix if needed
-            FindUniqueKey = (testKey as text, testCounter as number) as text =>
-                if Record.HasFields(existingRecord, {testKey}) then
-                    @FindUniqueKey(originalKey & "_" & Text.From(testCounter), testCounter + 1)
-                else
-                    testKey,
+            // Try original field name first
+            candidateName = fieldName,
             
-            uniqueKey = FindUniqueKey(newKey, counter),
-            result = Record.AddField(existingRecord, uniqueKey, newValue)
+            // If no conflict, return original name
+            finalName = if not List.Contains(existingFields, candidateName) then
+                candidateName
+            else if parentPath = "" then 
+                fieldName  // No parent path available, keep original
+            else
+                let
+                    // Split parent path and try adding parents one by one
+                    pathParts = Text.Split(parentPath, "."),
+                    reversedParts = List.Reverse(pathParts),  // Start with immediate parent
+                    
+                    // Use iteration instead of recursion
+                    ResolveWithIteration = () =>
+                        let
+                            // Generate all possible candidates
+                            candidates = List.Generate(
+                                () => [depth = 1, candidate = fieldName & "." & List.First(reversedParts)],
+                                each [depth] <= List.Count(reversedParts),
+                                each [
+                                    depth = [depth] + 1,
+                                    candidate = fieldName & "." & Text.Combine(List.FirstN(reversedParts, [depth]), ".")
+                                ],
+                                each [candidate]
+                            ),
+                            
+                            // Find first non-conflicting candidate
+                            firstNonConflicting = List.First(
+                                List.Select(candidates, each not List.Contains(existingFields, _)),
+                                // If all conflict, use full path
+                                fieldName & "." & Text.Combine(reversedParts, ".")
+                            )
+                        in
+                            firstNonConflicting,
+                    
+                    resolvedName = ResolveWithIteration()
+                in
+                    resolvedName
+        in
+            finalName,
+    
+    // Create the main flattening function with self-reference capability
+    FlattenRecordImpl = (
+        flattenFn as function,
+        inputRecord as any, 
+        targetFields as nullable list, 
+        parentPathParam as nullable text, 
+        existingFieldsParam as nullable list
+    ) as record =>
+        let
+            // Ensure non-null values for internal use
+            currentParentPath = if parentPathParam = null then "" else parentPathParam,
+            currentExistingFields = if existingFieldsParam = null then {} else existingFieldsParam,
+            currentTargetFields = targetFields,
+            
+            // Check if record has "properties" field and use it instead of the root record
+            recordToProcess = if inputRecord = null then 
+                null
+            else if Value.Is(inputRecord, type record) and Record.HasFields(inputRecord, {"properties"}) then
+                Record.Field(inputRecord, "properties")
+            else
+                inputRecord,
+            
+            // Helper function to check if a field should be included
+            ShouldIncludeField = (fieldName as text) as logical =>
+                if currentTargetFields = null then true
+                else List.Contains(currentTargetFields, fieldName),
+            
+            // Handle different input types
+            result = if recordToProcess = null then
+                []
+            else if Value.Is(recordToProcess, type record) then
+                let
+                    fieldNames = Record.FieldNames(recordToProcess),
+                    
+                    // Process each field
+                    processedFields = List.Accumulate(
+                        fieldNames,
+                        [FlattenedRecord = [], ExistingFieldsList = currentExistingFields],
+                        (state, fieldName) =>
+                            let
+                                fieldValue = Record.Field(recordToProcess, fieldName),
+                                newPath = if currentParentPath = "" then fieldName else currentParentPath & "." & fieldName,
+                                
+                                // Skip if path is excluded
+                                shouldProcess = not IsPathExcluded(newPath),
+                                
+                                processResult = if not shouldProcess then
+                                    state
+                                else
+                                    let
+                                        // Check if this is a name/value record
+                                        hasNameValue = Value.Is(fieldValue, type record) and 
+                                                     Record.HasFields(fieldValue, {"name", "value"}),
+                                        
+                                        finalResult = if hasNameValue then
+                                            let
+                                                nameField = Record.Field(fieldValue, "name"),
+                                                valueField = Record.Field(fieldValue, "value"),
+                                                // Check if this name field should be included
+                                                shouldInclude = if nameField = null then false else ShouldIncludeField(nameField),
+                                                result = if shouldInclude and nameField <> null then
+                                                    let
+                                                        resolvedName = ResolveFieldName(nameField, currentParentPath, state[ExistingFieldsList]),
+                                                        newRecord = Record.AddField(state[FlattenedRecord], resolvedName, valueField),
+                                                        newFieldsList = state[ExistingFieldsList] & {resolvedName}
+                                                    in
+                                                        [FlattenedRecord = newRecord, ExistingFieldsList = newFieldsList]
+                                                else
+                                                    state
+                                            in
+                                                result
+                                        else if fieldValue = null then
+                                            let
+                                                shouldInclude = ShouldIncludeField(fieldName),
+                                                result = if shouldInclude then
+                                                    let
+                                                        resolvedName = ResolveFieldName(fieldName, currentParentPath, state[ExistingFieldsList]),
+                                                        newRecord = Record.AddField(state[FlattenedRecord], resolvedName, null),
+                                                        newFieldsList = state[ExistingFieldsList] & {resolvedName}
+                                                    in
+                                                        [FlattenedRecord = newRecord, ExistingFieldsList = newFieldsList]
+                                                else
+                                                    state
+                                            in
+                                                result
+                                        else if Value.Is(fieldValue, type record) then
+                                            let
+                                                // Skip empty records
+                                                fieldCount = Record.FieldCount(fieldValue),
+                                                recursiveResult = if fieldCount = 0 then
+                                                    state
+                                                else
+                                                    let
+                                                        // Call the function through the passed reference
+                                                        flattened = flattenFn(flattenFn, fieldValue, currentTargetFields, newPath, state[ExistingFieldsList]),
+                                                        combinedRecord = flattened & state[FlattenedRecord],
+                                                        allFieldNames = Record.FieldNames(combinedRecord)
+                                                    in
+                                                        [FlattenedRecord = combinedRecord, ExistingFieldsList = allFieldNames]
+                                            in
+                                                recursiveResult
+                                        else if Value.Is(fieldValue, type list) then
+                                            let
+                                                listLength = List.Count(fieldValue),
+                                                // Skip empty lists
+                                                listResult = if listLength = 0 then
+                                                    state
+                                                else
+                                                    List.Accumulate(
+                                                        List.Positions(fieldValue),
+                                                        state,
+                                                        (listState, index) =>
+                                                            let
+                                                                listItem = fieldValue{index},
+                                                                indexSuffix = Text.From(index + 1), // 1-based indexing
+                                                                listFieldName = fieldName & "." & indexSuffix,
+                                                                listPath = if currentParentPath = "" then listFieldName else currentParentPath & "." & listFieldName,
+                                                                
+                                                                itemResult = if Value.Is(listItem, type record) then
+                                                                    let
+                                                                        itemFieldCount = Record.FieldCount(listItem),
+                                                                        itemFlattened = if itemFieldCount = 0 then
+                                                                            listState
+                                                                        else
+                                                                            let
+                                                                                // Call the function through the passed reference
+                                                                                flattened = flattenFn(flattenFn, listItem, currentTargetFields, listPath, listState[ExistingFieldsList]),
+                                                                                combinedRecord = flattened & listState[FlattenedRecord],
+                                                                                allFieldNames = Record.FieldNames(combinedRecord)
+                                                                            in
+                                                                                [FlattenedRecord = combinedRecord, ExistingFieldsList = allFieldNames]
+                                                                    in
+                                                                        itemFlattened
+                                                                else
+                                                                    let
+                                                                        shouldInclude = ShouldIncludeField(listFieldName),
+                                                                        result = if shouldInclude then
+                                                                            let
+                                                                                resolvedName = ResolveFieldName(listFieldName, currentParentPath, listState[ExistingFieldsList]),
+                                                                                newRecord = Record.AddField(listState[FlattenedRecord], resolvedName, listItem),
+                                                                                newFieldsList = listState[ExistingFieldsList] & {resolvedName}
+                                                                            in
+                                                                                [FlattenedRecord = newRecord, ExistingFieldsList = newFieldsList]
+                                                                        else
+                                                                            listState
+                                                                    in
+                                                                        result
+                                                            in
+                                                                itemResult
+                                                    )
+                                            in
+                                                listResult
+                                        else
+                                            // Handle primitive values
+                                            let
+                                                shouldInclude = ShouldIncludeField(fieldName),
+                                                result = if shouldInclude then
+                                                    let
+                                                        resolvedName = ResolveFieldName(fieldName, currentParentPath, state[ExistingFieldsList]),
+                                                        newRecord = Record.AddField(state[FlattenedRecord], resolvedName, fieldValue),
+                                                        newFieldsList = state[ExistingFieldsList] & {resolvedName}
+                                                    in
+                                                        [FlattenedRecord = newRecord, ExistingFieldsList = newFieldsList]
+                                                else
+                                                    state
+                                            in
+                                                result
+                                    in
+                                        finalResult
+                            in
+                                processResult
+                    )
+                in
+                    processedFields[FlattenedRecord]
+            else
+                // If input is not a record, return it as is in a record wrapper
+                [Value = recordToProcess]
         in
             result,
     
-    // enhanced combine function that handles duplicates and filtering
-    SafeRecordCombine = (records as list) as record =>
-        List.Accumulate(
-            records,
-            [],
-            (state, current) => 
-                List.Accumulate(
-                    Record.FieldNames(current),
-                    state,
-                    (innerState, fieldName) => 
-                        if ShouldIncludeKey(fieldName) then
-                            AddUniqueKey(innerState, fieldName, Record.Field(current, fieldName))
-                        else
-                            innerState
-                )
-        ),
-    
-    // helper function to process name-value objects
-    ProcessNameValueObject = (obj as record) as record =>
-        let
-            // Assert that the object has required fields
-            _ = if not (Record.HasFields(obj, {"name"}) and Record.HasFields(obj, {"value"})) then
-                error [
-                    Reason = "Invalid Name-Value Object",
-                    Message = "Object must have both 'name' and 'value' fields"
-                ]
-            else
-                null,
-                
-            BaseName = obj[name],
-            BaseValue = obj[value],
-            
-            // only extract name and value if it should be included
-            Result = if ShouldIncludeKey(BaseName) then
-                Record.FromList({BaseValue}, {BaseName})
-            else
-                []
-        in
-            Result,
-    
-    // helper function to process direct key-value objects
-    ProcessDirectKeyValueObject = (obj as record) as record =>
-        let
-            // assert that input is a record
-            _ = if not Value.Is(obj, type record) then
-                error [
-                    Reason = "Invalid Input Type",
-                    Message = "Expected record for direct key-value processing"
-                ]
-            else
-                null,
-                
-            // extract all primitive key-value pairs
-            PrimitiveFields = List.Transform(
-                Record.FieldNames(obj),
-                (fieldName) => 
-                    let
-                        fieldValue = Record.Field(obj, fieldName)
-                    in
-                        if not Type.Is(Value.Type(fieldValue), type record) and ShouldIncludeKey(fieldName) then
-                            Record.FromList({fieldValue}, {fieldName})
-                        else
-                            []
-            ),
-            
-            // filter out empty records and combine using safe combine
-            FilteredFields = List.Select(PrimitiveFields, (rec) => Record.FieldCount(rec) > 0),
-            Result = SafeRecordCombine(FilteredFields)
-        in
-            Result,
-    
-    // helper functions for type checking
-    HasDirectKeyValuePattern = (obj as record) as logical =>
-        List.AllTrue(
-            List.Transform(
-                Record.FieldValues(obj),
-                (value) => not Type.Is(Value.Type(value), type record)
-            )
-        ),
-    
-    IsNestedContainer = (obj as record) as logical =>
-        List.AnyTrue(
-            List.Transform(
-                Record.FieldValues(obj),
-                (value) => Type.Is(Value.Type(value), type record)
-            )
-        ),
-    
-    // main processing function with path tracking
-    ProcessField = (fieldName as text, fieldValue as any, currentPath as text) as record =>
-        let
-            fieldPath = if currentPath = "" then fieldName else currentPath & "." & fieldName
-        in
-            if IsExcludedPath(fieldPath) then
-                []
-            else if Type.Is(Value.Type(fieldValue), type record) then
-                if Record.HasFields(fieldValue, {"name", "value"}) then
-                    ProcessNameValueObject(fieldValue)
-                else if HasDirectKeyValuePattern(fieldValue) then
-                    ProcessDirectKeyValueObject(fieldValue)
-                else if IsNestedContainer(fieldValue) then
-                    // recursive call for nested containers
-                    @ProcessRecord(fieldValue, fieldPath)
-                else
-                    // unknown record type, skip
-                    []
-            else
-                // primitive value - check if should be included
-                if ShouldIncludeKey(fieldName) then
-                    Record.FromList({fieldValue}, {fieldName})
-                else
-                    [],
-    
-    // process entire record recursively
-    ProcessRecord = (record as record, currentPath as text) as record =>
-        let
-            // assert that input is a record
-            _ = if not Value.Is(record, type record) then
-                error [
-                    Reason = "Invalid Record Type",
-                    Message = "Expected record for processing, but received: " & Text.From(Value.Type(record))
-                ]
-            else
-                null,
-                
-            ProcessedFields = List.Transform(
-                Record.FieldNames(record),
-                (fieldName) => ProcessField(fieldName, Record.Field(record, fieldName), currentPath)
-            ),
-            FilteredFields = List.Select(ProcessedFields, (rec) => Record.FieldCount(rec) > 0),
-            CombinedRecord = SafeRecordCombine(FilteredFields)
-        in
-            CombinedRecord,
-    
-    // assert that input is a record before processing
-    _ = if not Value.Is(ActualInput, type record) then
-        error [
-            Reason = "Invalid Input Type",
-            Message = "Input must be a record, but received: " & Text.From(Value.Type(ActualInput))
-        ]
-    else
-        null,
-    
-    // start processing from root
-    Result = ProcessRecord(ActualInput, "")
+    // Call the implementation with self-reference
+    result = FlattenRecordImpl(FlattenRecordImpl, inputRecord, targetFields, parentPath, existingFields)
 in
-    Result 
+    result


### PR DESCRIPTION
This PR adds multiple improvements to how Objects.Properties helper functions works.

1. Adds parameter group as a suffix instead of a number (_1). It is especially useful when dealing with a large number of properties where there are duplicate property names under different groups. 

    It uses a progressive qualification approach:

    1. First attempt: Use original field name (e.g., `Width`)
    2. First conflict: Add immediate parent (e.g., `Width.Dimensions`)
    3. Subsequent conflicts: Add next level up (e.g., `Width.Dimensions.TypeParameters`)
    4. Continue: Keep adding hierarchy levels until the name is unique

2. Lists: Array elements are indexed with 1-based numbering now(`Field.1, Field.2`). Previously list values of properties were not handled at all.
3. filterKeys function now returns all instances instead of exact match. For example: if you filter by `id`, now it returns both `id` and `id.ElementTypeAttributes` for an IFC file.

Functions signature has changes but this won't affect any existing uses of the function as we added 2 more inputs at the end.
```
FlattenRecord(
    inputRecord as any,           // The record to flatten
    optional filterKeys as list, // List of specific field names to extract
    optional parentPath as text,   // Internal: parent path for recursion
    optional existingFields as list // Internal: existing field names for conflict resolution
) as record
```
## Performance Benchmark
I tested it with different models and there were no major regressions in load times. Here are the results:


Model Name | Old | New |  
-- | -- | -- | --
Speckle Tower | 00:11 | 00:11 | https://app.speckle.systems/projects/57bbfabd80/models/eeb52598d4
Snowdon Architectural | 00:22 | 00:23 | https://app.speckle.systems/projects/6006329713/models/5496e0a4ec
Snowdon Structural | 00:11 | 00:12 | https://app.speckle.systems/projects/6006329713/models/c0a4fdb134
Simple Shed | 00:02.46 | 00:03 | https://app.speckle.systems/projects/6006329713/models/d5a15dc886
Archicad hillside house | 00:07 | 00:07 | https://app.speckle.systems/projects/1b96a34aae/models/2e69fdf5cc
IFC model | 00:40 | 00:31 | https://app.speckle.systems/projects/8fca752f9b/models/caedc97f7a
## Screenshots
Before
<img width="653" height="751" alt="image" src="https://github.com/user-attachments/assets/eb9d77cf-8cff-49fc-80b2-aa55a7c4f96b" />

After
<img width="564" height="731" alt="image" src="https://github.com/user-attachments/assets/1c9d5fc3-c7aa-4812-9adf-c4710dffc4a7" />
