### PR TITLE
Add Models.MaterialQuantities helper function

### DIFF
--- a/src/powerbi-data-connector/Speckle.pq
+++ b/src/powerbi-data-connector/Speckle.pq
@@ -184,6 +184,11 @@ shared Speckle.Models.Federate = Value.ReplaceType(
     type function (tables as list, optional excludeData as logical) as table
 );
 
+shared Speckle.Models.MaterialQuantities = Value.ReplaceType(
+    Speckle.LoadFunction("Models.MaterialQuantities.pqm"),
+    type function (inputTable as table) as table
+);
+
 [DataSource.Kind = "Speckle", Publish="GetByUrl.Publish"]
 shared Speckle.GetByUrl = Value.ReplaceType(
     Speckle.LoadFunction("GetByUrl.pqm"),

--- a/src/powerbi-data-connector/Speckle.pq
+++ b/src/powerbi-data-connector/Speckle.pq
@@ -186,7 +186,7 @@ shared Speckle.Models.Federate = Value.ReplaceType(
 
 shared Speckle.Models.MaterialQuantities = Value.ReplaceType(
     Speckle.LoadFunction("Models.MaterialQuantities.pqm"),
-    type function (inputTable as table) as table
+    type function (inputTable as table, optional addPrefix as logical) as table
 );
 
 [DataSource.Kind = "Speckle", Publish="GetByUrl.Publish"]

--- a/src/powerbi-data-connector/speckle/api/Models.MaterialQuantities.pqm
+++ b/src/powerbi-data-connector/speckle/api/Models.MaterialQuantities.pqm
@@ -1,0 +1,19 @@
+// function for transforming a table to extract and expand Material Quantities data
+(inputTable as table) as table =>
+let
+    // Add MQ column using existing MaterialQuantities function with list output
+    AddedMQ = Table.AddColumn(inputTable, "MQ", each Speckle.Objects.MaterialQuantities([data], true)),
+    
+    // Expand the MQ list column
+    ExpandMQ = Table.ExpandListColumn(AddedMQ, "MQ"),
+    
+    // Add MQProperties column using Properties function with error handling
+    AddedMQProperties = Table.AddColumn(ExpandMQ, "MQProperties", each try Speckle.Objects.Properties([MQ]) otherwise null),
+    
+    // Expand the MQProperties record using Utils.ExpandRecord
+    ExpandMQProperties = Speckle.Utils.ExpandRecord(AddedMQProperties, "MQProperties"),
+    
+    // Remove the temporary MQ and MQProperties columns
+    RemovedColumns = Table.RemoveColumns(ExpandMQProperties, {"MQ", "MQProperties"}, MissingField.Ignore)
+in
+    RemovedColumns

--- a/src/powerbi-data-connector/speckle/api/Models.MaterialQuantities.pqm
+++ b/src/powerbi-data-connector/speckle/api/Models.MaterialQuantities.pqm
@@ -1,19 +1,22 @@
 // function for transforming a table to extract and expand Material Quantities data
-(inputTable as table) as table =>
+(inputTable as table, optional addPrefix as logical) as table =>
 let
-    // Add MQ column using existing MaterialQuantities function with list output
-    AddedMQ = Table.AddColumn(inputTable, "MQ", each Speckle.Objects.MaterialQuantities([data], true)),
+    // Default addPrefix to false if not provided
+    UsePrefix = if addPrefix = null then false else addPrefix,
     
-    // Expand the MQ list column
-    ExpandMQ = Table.ExpandListColumn(AddedMQ, "MQ"),
+    // Add mq column using existing MaterialQuantities function with list output
+    AddedMQ = Table.AddColumn(inputTable, "mq", each Speckle.Objects.MaterialQuantities([data], true)),
+    
+    // Expand the mq list column
+    ExpandMQ = Table.ExpandListColumn(AddedMQ, "mq"),
     
     // Add MQProperties column using Properties function with error handling
-    AddedMQProperties = Table.AddColumn(ExpandMQ, "MQProperties", each try Speckle.Objects.Properties([MQ]) otherwise null),
+    AddedMQProperties = Table.AddColumn(ExpandMQ, "MQ", each try Speckle.Objects.Properties([mq]) otherwise null),
     
     // Expand the MQProperties record using Utils.ExpandRecord
-    ExpandMQProperties = Speckle.Utils.ExpandRecord(AddedMQProperties, "MQProperties"),
+    ExpandMQProperties = Speckle.Utils.ExpandRecord(AddedMQProperties, "MQ", null, UsePrefix),
     
-    // Remove the temporary MQ and MQProperties columns
-    RemovedColumns = Table.RemoveColumns(ExpandMQProperties, {"MQ", "MQProperties"}, MissingField.Ignore)
+    // Remove the temporary mq and MQProperties columns
+    FinalTable = Table.RemoveColumns(ExpandMQProperties, {"mq", "MQ"}, MissingField.Ignore)
 in
-    RemovedColumns
+    FinalTable


### PR DESCRIPTION
Added new Models.MaterialQuantities helper function to streamline material quantities extraction and expansion. Idea for this helper function came from @jsdbroughton . It's encapsulates common transformation patterns for material quantities intoa single function.

// Basic usage - creates columns like "materialName", "area"
`Speckle.Models.MaterialQuantities(sourceTable)`

// With prefixing - creates "MQ.materialName", "MQ.area"
`Speckle.Models.MaterialQuantities(sourceTable, true)`

<img width="1918" height="1080" alt="image" src="https://github.com/user-attachments/assets/0652eea8-b403-4d5e-9e05-26ec32f0446a" />
