### PR TITLE
feat (data): remove token and anonymous authentication

### DIFF
--- a/src/powerbi-data-connector/Speckle.pq
+++ b/src/powerbi-data-connector/Speckle.pq
@@ -247,7 +247,7 @@ GetByUrl.Icons = [
 Speckle = [
     // This is used when running the connector on an on-premises data gateway
     TestConnection = (path) => {"Speckle.GetUser", path},
-    // Authentication strategy
+    // Authentication strategy - OAuth only
     Authentication = [
         OAuth = [
             Label = "Speckle Account",
@@ -357,13 +357,6 @@ Speckle = [
                         ]
                 in
                     result
-        ],
-        Key = [
-            KeyLabel = "Personal Access Token",
-            Label = "Private Project"
-        ],
-        Implicit = [
-            Label = "Public Project"
         ]
     ],
     Label = "Speckle"

--- a/src/powerbi-data-connector/speckle/api/Api.Fetch.pqm
+++ b/src/powerbi-data-connector/speckle/api/Api.Fetch.pqm
@@ -1,7 +1,7 @@
 (server as text, optional query as text, optional variables as record) as record =>
     let
         // Enhanced credential retrieval with OAuth2 support
-        apiKey = try Extension.CurrentCredential()[Key] otherwise try Extension.CurrentCredential()[access_token] otherwise null,
+        apiKey = try Extension.CurrentCredential()[access_token] otherwise null,
         
         defaultQuery = "query {
                 activeUser {

--- a/src/powerbi-data-connector/speckle/api/GetModel.pqm
+++ b/src/powerbi-data-connector/speckle/api/GetModel.pqm
@@ -29,7 +29,7 @@
         versionId = parsedUrl[versionId],
         
         // get API key if available
-        apiKey = try Extension.CurrentCredential()[Key] otherwise null,
+        apiKey = try Extension.CurrentCredential()[access_token] otherwise null,
         
         // graphql query to get model info including root object id
         // includes specific version if provided

--- a/src/powerbi-data-connector/speckle/api/GetUser.pqm
+++ b/src/powerbi-data-connector/speckle/api/GetUser.pqm
@@ -26,7 +26,7 @@ in
             parsedUrl = Parser(url),
             server = parsedUrl[baseUrl],
             
-            apiKey = try Extension.CurrentCredential()[Key] otherwise try Extension.CurrentCredential()[access_token] otherwise "",
+            apiKey = try Extension.CurrentCredential()[access_token] otherwise "",
             
             query = "query {
                     activeUser {


### PR DESCRIPTION
In this PR we're removing personal access token and anonymous (it was from pre-workspace era) authentication methods. Only authentication method will be OAuth. This is done for some security measurements related to token exchange. 

<img width="872" height="334" alt="Screenshot_1" src="https://github.com/user-attachments/assets/35aba192-170f-47c5-9b25-90ed27c63439" />

Note: Also there was a small bug about writing receive info to the file, that's fixed.