### PR TITLE
fix (visual): remove forcing conditional formatted objects always be visible

### DIFF
--- a/src/powerbi-visual/src/store/visualStore.ts
+++ b/src/powerbi-visual/src/store/visualStore.ts
@@ -139,6 +139,23 @@ export const useVisualStore = defineStore('visualStore', () => {
     }
   }
 
+  const filterColorByIdsForSelection = (colorByIds: ColorBy[] | null | undefined, selectedIds: string[]): ColorBy[] => {
+    return colorByIds?.filter(colorGroup => {
+      const filteredObjectIds = colorGroup.objectIds.filter(objId =>
+        selectedIds.includes(objId)
+      )
+      if (filteredObjectIds.length > 0) {
+        return { ...colorGroup, objectIds: filteredObjectIds }
+      }
+      return false
+    }).map(colorGroup => ({
+      ...colorGroup,
+      objectIds: colorGroup.objectIds.filter(objId =>
+        selectedIds.includes(objId)
+      )
+    })) || []
+  }
+
   const clearLoadingProgress = () => {
     loadingProgress.value = undefined
   }
@@ -197,23 +214,7 @@ export const useVisualStore = defineStore('visualStore', () => {
       viewerEmit.value('filterSelection', dataInput.value.selectedIds, isGhostActive.value, isZoomOnFilterActive.value)
 
       // When filtering, only apply colors to the selected/isolated objects
-      // Filter colorByIds to only include colors for selected objects
-      const filteredColorByIds = dataInput.value.colorByIds?.filter(colorGroup => {
-        // Keep only color groups that have at least one object in the selected IDs
-        const filteredObjectIds = colorGroup.objectIds.filter(objId =>
-          dataInput.value.selectedIds.includes(objId)
-        )
-        if (filteredObjectIds.length > 0) {
-          return { ...colorGroup, objectIds: filteredObjectIds }
-        }
-        return false
-      }).map(colorGroup => ({
-        ...colorGroup,
-        objectIds: colorGroup.objectIds.filter(objId =>
-          dataInput.value.selectedIds.includes(objId)
-        )
-      }))
-
+      const filteredColorByIds = filterColorByIdsForSelection(dataInput.value.colorByIds, dataInput.value.selectedIds)
       viewerEmit.value('colorObjectsByGroup', filteredColorByIds)
     } else {
       isFilterActive.value = false
@@ -501,21 +502,7 @@ export const useVisualStore = defineStore('visualStore', () => {
         viewerEmit.value('filterSelection', dataInput.value.selectedIds, isGhostActive.value, isZoomOnFilterActive.value)
 
         // When filtering, only apply colors to the selected/isolated objects
-        const filteredColorByIds = dataInput.value.colorByIds?.filter(colorGroup => {
-          const filteredObjectIds = colorGroup.objectIds.filter(objId =>
-            dataInput.value.selectedIds.includes(objId)
-          )
-          if (filteredObjectIds.length > 0) {
-            return { ...colorGroup, objectIds: filteredObjectIds }
-          }
-          return false
-        }).map(colorGroup => ({
-          ...colorGroup,
-          objectIds: colorGroup.objectIds.filter(objId =>
-            dataInput.value.selectedIds.includes(objId)
-          )
-        }))
-
+        const filteredColorByIds = filterColorByIdsForSelection(dataInput.value.colorByIds, dataInput.value.selectedIds)
         viewerEmit.value('colorObjectsByGroup', filteredColorByIds)
       } else {
         isFilterActive.value = false

--- a/src/powerbi-visual/src/utils/matrixViewUtils.ts
+++ b/src/powerbi-visual/src/utils/matrixViewUtils.ts
@@ -131,7 +131,8 @@ function processObjectNode(
     console.log('⚠️ HAS objects', color)
     if (color) {
       res.color = color
-      res.shouldColor = true
+      // Don't override shouldColor for conditional formatting - keep the selection state
+      // res.shouldColor = true  // REMOVED: This was overriding cross-filter selection state
     }
   }
   return res
@@ -474,6 +475,7 @@ export async function processMatrixView(
     localMatrixView.forEach((obj) => {
       const processedObjectIdLevels = processObjectIdLevel(obj, host, matrixView)
 
+      // Apply conditional formatting color if present, regardless of selection state
       if (processedObjectIdLevels.color) {
         let group = colorByIds.find((g) => g.color === processedObjectIdLevels.color)
         if (!group) {
@@ -483,7 +485,11 @@ export async function processMatrixView(
           }
           colorByIds.push(group)
         }
+        // Always add to color group if color is specified (conditional formatting)
         group.objectIds.push(processedObjectIdLevels.id)
+      } else if (processedObjectIdLevels.shouldColor) {
+        // Only use shouldColor flag when there's no conditional formatting
+        // This preserves the original cross-filter coloring behavior
       }
 
       objectIds.push(processedObjectIdLevels.id)


### PR DESCRIPTION
Implemented a fix for clash between our isolation logic and Power BI conditional formatting. 

`res.shouldColor = true` was forcing colored objects should always be visible and it was overriding cross-filter selection state. Now we apply colors to only visible objects. 