### PR TITLE
feat (visual): context mode

### DIFF
--- a/src/powerbi-data-connector/speckle/api/SendToServer.pqm
+++ b/src/powerbi-data-connector/speckle/api/SendToServer.pqm
@@ -33,6 +33,29 @@
         connectorVersion = GetVersion(),
         workspaceInfo = GetWorkspace(url),
 
+        // get model names 
+        modelNames = if parsedUrl[isFederated] = true then
+            // for federated models, loop through
+            List.Transform(
+                parsedUrl[federatedModels],
+                each
+                    let
+                        singleModelUrl = Text.Combine({
+                            parsedUrl[baseUrl],
+                            "/projects/",
+                            parsedUrl[projectId],
+                            "/models/",
+                            [modelId],
+                            if [versionId] <> null then Text.Combine({"@", [versionId]}) else ""
+                        }),
+                        singleModelInfo = GetModel(singleModelUrl)
+                    in
+                        singleModelInfo[modelName]
+            )
+        else
+            // single model
+            {modelInfo[modelName]},
+
         // Function to check if Desktop Service is available
         IsDesktopServiceAvailable = () =>
             try

--- a/src/powerbi-data-connector/speckle/api/SendToServer.pqm
+++ b/src/powerbi-data-connector/speckle/api/SendToServer.pqm
@@ -33,29 +33,6 @@
         connectorVersion = GetVersion(),
         workspaceInfo = GetWorkspace(url),
 
-        // get model names 
-        modelNames = if parsedUrl[isFederated] = true then
-            // for federated models, loop through
-            List.Transform(
-                parsedUrl[federatedModels],
-                each
-                    let
-                        singleModelUrl = Text.Combine({
-                            parsedUrl[baseUrl],
-                            "/projects/",
-                            parsedUrl[projectId],
-                            "/models/",
-                            [modelId],
-                            if [versionId] <> null then Text.Combine({"@", [versionId]}) else ""
-                        }),
-                        singleModelInfo = GetModel(singleModelUrl)
-                    in
-                        singleModelInfo[modelName]
-            )
-        else
-            // single model
-            {modelInfo[modelName]},
-
         // Function to check if Desktop Service is available
         IsDesktopServiceAvailable = () =>
             try

--- a/src/powerbi-visual/capabilities.json
+++ b/src/powerbi-visual/capabilities.json
@@ -142,6 +142,13 @@
         }
       }
     },
+    "contextMode": {
+      "properties": {
+        "settings": {
+          "type": { "text": true }
+        }
+      }
+    },
     "color": {
       "properties": {
         "enabled": {

--- a/src/powerbi-visual/src/components/ViewerControls.vue
+++ b/src/powerbi-visual/src/components/ViewerControls.vue
@@ -48,6 +48,12 @@
         @update:open="(value) => toggleActiveControl(value ? 'views' : 'none')"
         @view-clicked="(view) => $emit('view-clicked', view)"
       />
+      <!-- Context Mode -->
+      <ViewerContextModeMenu
+        v-if="visualStore.isFederatedModel"
+        :open="contextModeOpen"
+        @update:open="(value) => toggleActiveControl(value ? 'contextMode' : 'none')"
+      />
       <!-- Perspective/Ortho -->
       <ViewerControlsButtonToggle
         flat
@@ -73,6 +79,7 @@ import ViewerControlsButtonToggle from './viewer/controls/ViewerControlsButtonTo
 
 import ViewerViewModesMenu from './viewer/view-modes/ViewerViewModesMenu.vue'
 import ViewerViewsMenu from './viewer/views/ViewerViewsMenu.vue'
+import ViewerContextModeMenu from './viewer/context-mode/ViewerContextModeMenu.vue'
 
 import Perspective from '../components/global/icon/Perspective.vue'
 import PerspectiveMore from '../components/global/icon/PerspectiveMore.vue'
@@ -97,6 +104,7 @@ type ActiveControl =
   | 'none'
   | 'viewModes'
   | 'views'
+  | 'contextMode'
   | 'sun'
   | 'projection'
   | 'sectionBox'
@@ -141,6 +149,13 @@ const viewsOpen = computed({
   get: () => activeControl.value === 'views',
   set: (value) => {
     activeControl.value = value ? 'views' : 'none'
+  }
+})
+
+const contextModeOpen = computed({
+  get: () => activeControl.value === 'contextMode',
+  set: (value) => {
+    activeControl.value = value ? 'contextMode' : 'none'
   }
 })
 </script>

--- a/src/powerbi-visual/src/components/ViewerWrapper.vue
+++ b/src/powerbi-visual/src/components/ViewerWrapper.vue
@@ -176,21 +176,30 @@ onBeforeUnmount(async () => {
 async function handleObjectClicked(hit: any, isMultiSelect: boolean, mouseEvent?: PointerEvent) {
   // Skip if dragging occurred
   if (dragged.value) return
-  
+
   console.log('🎯 Object clicked in ViewerWrapper:', hit, isMultiSelect)
-  
+
   if (hit) {
     visualStore.setPostClickSkipNeeded(true)
     const id = hit.object.id as string
-    if (isMultiSelect || !selectionHandler.isSelected(id)) {
-      await selectionHandler.select(id, isMultiSelect)
+
+    // check if the objects are set to interactive before triggering selection
+    const isInteractive = visualStore.isObjectInteractive(id)
+
+    if (isInteractive) {
+      // only register selection if object is from a interactive model
+      if (isMultiSelect || !selectionHandler.isSelected(id)) {
+        await selectionHandler.select(id, isMultiSelect)
+      }
+    } else {
+      console.log(`🚫 Object ${id} is from a non-interactive model, skipping PowerBI selection`)
     }
-    
+
     // Show tooltip if we have mouse coordinates
     if (mouseEvent) {
       tooltipHandler.show(hit, { x: mouseEvent.clientX, y: mouseEvent.clientY })
     }
-    
+
     const selection = selectionHandler.getCurrentSelection()
     const ids = selection.map((s) => s.id)
     await viewerHandler.selectObjects(ids)

--- a/src/powerbi-visual/src/components/ViewerWrapper.vue
+++ b/src/powerbi-visual/src/components/ViewerWrapper.vue
@@ -192,7 +192,7 @@ async function handleObjectClicked(hit: any, isMultiSelect: boolean, mouseEvent?
         await selectionHandler.select(id, isMultiSelect)
       }
     } else {
-      console.log(`🚫 Object ${id} is from a non-interactive model, skipping PowerBI selection`)
+      console.log(`Object ${id} is from a non-interactive model, skipping selection`)
     }
 
     // Show tooltip if we have mouse coordinates

--- a/src/powerbi-visual/src/components/global/icon/Context.vue
+++ b/src/powerbi-visual/src/components/global/icon/Context.vue
@@ -1,0 +1,16 @@
+<template>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    stroke-width="1.5"
+    stroke="currentColor"
+  >
+    <path
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      d="M6.429 9.75 2.25 12l4.179 2.25m0-4.5 5.571 3 5.571-3m-11.142 0L2.25 7.5 12 2.25l9.75 5.25-4.179 2.25m0 0L21.75 12l-4.179 2.25m0 0 4.179 2.25L12 21.75 2.25 16.5l4.179-2.25m11.142 0-5.571 3-5.571-3"
+    />
+  </svg>
+</template>
+

--- a/src/powerbi-visual/src/components/viewer/context-mode/ViewerContextModeMenu.vue
+++ b/src/powerbi-visual/src/components/viewer/context-mode/ViewerContextModeMenu.vue
@@ -1,0 +1,90 @@
+<template>
+  <ViewerMenu v-model:open="open" tooltip="Context Mode">
+    <template #trigger-icon>
+      <Context class="h-5 w-5" />
+    </template>
+    <template #title>Context Mode</template>
+    <div class="p-1 space-y-2">
+      <div v-for="model in modelMetadata" :key="model.modelId" class="pb-2 border-b border-outline-2 last:border-0">
+        <div class="flex items-center gap-1">
+          <div class="text-xs font-medium text-foreground truncate max-w-[80px]">{{ model.modelName }}</div>
+          <!-- Visibility toggle -->
+          <button
+            class="p-1 rounded transition flex items-center justify-center"
+            :class="
+              getSettings(model.modelId).visible
+                ? 'bg-primary text-white'
+                : 'bg-foundation-2 text-foreground hover:bg-highlight-1'
+            "
+            @click="toggleVisibility(model.modelId)"
+          >
+            <EyeIcon v-if="getSettings(model.modelId).visible" class="h-4 w-4" />
+            <EyeSlashIcon v-else class="h-4 w-4" />
+          </button>
+
+          <!-- Lock toggle -->
+          <button
+            class="p-1 rounded transition flex items-center justify-center"
+            :class="
+              getSettings(model.modelId).locked
+                ? 'bg-foundation-2 text-foreground hover:bg-highlight-1'
+                : 'bg-primary text-white'
+            "
+            :disabled="!getSettings(model.modelId).visible"
+            @click="toggleLock(model.modelId)"
+          >
+            <LockClosedIcon v-if="getSettings(model.modelId).locked" class="h-4 w-4" />
+            <LockOpenIcon v-else class="h-4 w-4" />
+          </button>
+        </div>
+      </div>
+    </div>
+  </ViewerMenu>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useVisualStore } from '@src/store/visualStore'
+import ViewerMenu from '../menu/ViewerMenu.vue'
+import Context from '../../global/icon/Context.vue'
+import { LockClosedIcon, LockOpenIcon, EyeIcon, EyeSlashIcon } from '@heroicons/vue/24/outline'
+
+const visualStore = useVisualStore()
+
+const props = defineProps<{
+  open: boolean
+}>()
+
+const emit = defineEmits<{
+  (e: 'update:open', value: boolean): void
+}>()
+
+const open = computed({
+  get: () => props.open,
+  set: (val) => emit('update:open', val)
+})
+
+const modelMetadata = computed(() => visualStore.modelMetadata)
+
+const getSettings = (modelId: string) => {
+  return visualStore.getModelContextSettings(modelId)
+}
+
+const toggleVisibility = (modelId: string) => {
+  const current = getSettings(modelId)
+  const newSettings = { ...current, visible: !current.visible }
+
+  visualStore.setModelContextMode(modelId, newSettings)
+  visualStore.viewerEmit('applyContextMode', modelId, newSettings)
+  visualStore.writeContextModeToFile()
+}
+
+const toggleLock = (modelId: string) => {
+  const current = getSettings(modelId)
+  const newSettings = { ...current, locked: !current.locked }
+
+  visualStore.setModelContextMode(modelId, newSettings)
+  visualStore.viewerEmit('applyContextMode', modelId, newSettings)
+  visualStore.writeContextModeToFile()
+}
+</script>

--- a/src/powerbi-visual/src/components/viewer/context-mode/ViewerContextModeMenu.vue
+++ b/src/powerbi-visual/src/components/viewer/context-mode/ViewerContextModeMenu.vue
@@ -36,6 +36,22 @@
             <LockClosedIcon v-if="getSettings(model.rootObjectId).locked" class="h-4 w-4" />
             <LockOpenIcon v-else class="h-4 w-4" />
           </button>
+
+          <!-- Interactive toggle -->
+          <button
+            class="p-1 rounded transition flex items-center justify-center"
+            :class="
+              getSettings(model.rootObjectId).interactive
+                ? 'bg-primary text-white'
+                : 'bg-foundation-2 text-foreground hover:bg-highlight-1'
+            "
+            :disabled="!getSettings(model.rootObjectId).visible"
+            :title="getSettings(model.rootObjectId).interactive ? 'Interactive (participates in cross-filtering)' : 'Non-interactive (no cross-filtering)'"
+            @click="toggleInteractive(model.rootObjectId)"
+          >
+            <LinkIcon v-if="getSettings(model.rootObjectId).interactive" class="h-4 w-4" />
+            <LinkSlashIcon v-else class="h-4 w-4" />
+          </button>
         </div>
       </div>
     </div>
@@ -47,7 +63,7 @@ import { computed } from 'vue'
 import { useVisualStore } from '@src/store/visualStore'
 import ViewerMenu from '../menu/ViewerMenu.vue'
 import Context from '../../global/icon/Context.vue'
-import { LockClosedIcon, LockOpenIcon, EyeIcon, EyeSlashIcon } from '@heroicons/vue/24/outline'
+import { LockClosedIcon, LockOpenIcon, EyeIcon, EyeSlashIcon, LinkIcon, LinkSlashIcon } from '@heroicons/vue/24/outline'
 
 const visualStore = useVisualStore()
 
@@ -72,7 +88,15 @@ const getSettings = (rootObjectId: string) => {
 
 const toggleVisibility = (rootObjectId: string) => {
   const current = getSettings(rootObjectId)
-  const newSettings = { ...current, visible: !current.visible }
+  const newVisible = !current.visible
+
+  // hidden models get non-interactive automatically
+  // ux would be very confusing otherwise
+  const newSettings = {
+    ...current,
+    visible: newVisible,
+    interactive: newVisible ? current.interactive : false
+  }
 
   visualStore.setModelContextMode(rootObjectId, newSettings)
   visualStore.viewerEmit('applyContextMode', rootObjectId, newSettings)
@@ -86,5 +110,20 @@ const toggleLock = (rootObjectId: string) => {
   visualStore.setModelContextMode(rootObjectId, newSettings)
   visualStore.viewerEmit('applyContextMode', rootObjectId, newSettings)
   visualStore.writeContextModeToFile()
+}
+
+const toggleInteractive = (rootObjectId: string) => {
+  const current = getSettings(rootObjectId)
+  const newSettings = { ...current, interactive: !current.interactive }
+
+  visualStore.setModelContextMode(rootObjectId, newSettings)
+  visualStore.viewerEmit('applyContextMode', rootObjectId, newSettings)
+  visualStore.writeContextModeToFile()
+
+  // need to rebuild selection registrations
+  visualStore.setPostClickSkipNeeded(false)
+
+  // need to refresh host data for selection registration
+  visualStore.host.refreshHostData()
 }
 </script>

--- a/src/powerbi-visual/src/components/viewer/context-mode/ViewerContextModeMenu.vue
+++ b/src/powerbi-visual/src/components/viewer/context-mode/ViewerContextModeMenu.vue
@@ -5,20 +5,20 @@
     </template>
     <template #title>Context Mode</template>
     <div class="p-1 space-y-2">
-      <div v-for="model in modelMetadata" :key="model.modelId" class="pb-2 border-b border-outline-2 last:border-0">
+      <div v-for="model in modelMetadata" :key="model.rootObjectId" class="pb-2 border-b border-outline-2 last:border-0">
         <div class="flex items-center gap-1">
           <div class="text-xs font-medium text-foreground truncate max-w-[80px]">{{ model.modelName }}</div>
           <!-- Visibility toggle -->
           <button
             class="p-1 rounded transition flex items-center justify-center"
             :class="
-              getSettings(model.modelId).visible
+              getSettings(model.rootObjectId).visible
                 ? 'bg-primary text-white'
                 : 'bg-foundation-2 text-foreground hover:bg-highlight-1'
             "
-            @click="toggleVisibility(model.modelId)"
+            @click="toggleVisibility(model.rootObjectId)"
           >
-            <EyeIcon v-if="getSettings(model.modelId).visible" class="h-4 w-4" />
+            <EyeIcon v-if="getSettings(model.rootObjectId).visible" class="h-4 w-4" />
             <EyeSlashIcon v-else class="h-4 w-4" />
           </button>
 
@@ -26,14 +26,14 @@
           <button
             class="p-1 rounded transition flex items-center justify-center"
             :class="
-              getSettings(model.modelId).locked
+              getSettings(model.rootObjectId).locked
                 ? 'bg-foundation-2 text-foreground hover:bg-highlight-1'
                 : 'bg-primary text-white'
             "
-            :disabled="!getSettings(model.modelId).visible"
-            @click="toggleLock(model.modelId)"
+            :disabled="!getSettings(model.rootObjectId).visible"
+            @click="toggleLock(model.rootObjectId)"
           >
-            <LockClosedIcon v-if="getSettings(model.modelId).locked" class="h-4 w-4" />
+            <LockClosedIcon v-if="getSettings(model.rootObjectId).locked" class="h-4 w-4" />
             <LockOpenIcon v-else class="h-4 w-4" />
           </button>
         </div>
@@ -66,25 +66,25 @@ const open = computed({
 
 const modelMetadata = computed(() => visualStore.modelMetadata)
 
-const getSettings = (modelId: string) => {
-  return visualStore.getModelContextSettings(modelId)
+const getSettings = (rootObjectId: string) => {
+  return visualStore.getModelContextSettings(rootObjectId)
 }
 
-const toggleVisibility = (modelId: string) => {
-  const current = getSettings(modelId)
+const toggleVisibility = (rootObjectId: string) => {
+  const current = getSettings(rootObjectId)
   const newSettings = { ...current, visible: !current.visible }
 
-  visualStore.setModelContextMode(modelId, newSettings)
-  visualStore.viewerEmit('applyContextMode', modelId, newSettings)
+  visualStore.setModelContextMode(rootObjectId, newSettings)
+  visualStore.viewerEmit('applyContextMode', rootObjectId, newSettings)
   visualStore.writeContextModeToFile()
 }
 
-const toggleLock = (modelId: string) => {
-  const current = getSettings(modelId)
+const toggleLock = (rootObjectId: string) => {
+  const current = getSettings(rootObjectId)
   const newSettings = { ...current, locked: !current.locked }
 
-  visualStore.setModelContextMode(modelId, newSettings)
-  visualStore.viewerEmit('applyContextMode', modelId, newSettings)
+  visualStore.setModelContextMode(rootObjectId, newSettings)
+  visualStore.viewerEmit('applyContextMode', rootObjectId, newSettings)
   visualStore.writeContextModeToFile()
 }
 </script>

--- a/src/powerbi-visual/src/extensions/FilteredSelectionExtension.ts
+++ b/src/powerbi-visual/src/extensions/FilteredSelectionExtension.ts
@@ -163,7 +163,6 @@ export class FilteredSelectionExtension extends SelectionExtension {
   }
 
   protected onObjectDoubleClick(selection: SelectionEvent | null) {
-    console.log('🎯 FilteredSelectionExtension.onObjectDoubleClick called with:', selection)
 
     if (!selection || !selection.hits || selection.hits.length === 0) {
       super.onObjectDoubleClick(selection)
@@ -174,7 +173,6 @@ export class FilteredSelectionExtension extends SelectionExtension {
     for (const hit of selection.hits) {
       const objectId = hit.node.model.id
       if (this.isNonInteractiveObject(objectId)) {
-        console.log('🚫 Preventing zoom on non-interactive object:', objectId)
         return
       }
     }

--- a/src/powerbi-visual/src/extensions/FilteredSelectionExtension.ts
+++ b/src/powerbi-visual/src/extensions/FilteredSelectionExtension.ts
@@ -21,6 +21,7 @@ export interface FilteredSelectionEventPayload {
 
 export class FilteredSelectionExtension extends SelectionExtension {
   private lockedObjectsGetter: (() => Set<string>) | null = null
+  private nonInteractiveObjectsGetter: (() => string[]) | null = null
 
   // We're adding the Filtering Extension
   public get inject(): Array<new (viewer: IViewer, ...args: any[]) => any> {
@@ -37,6 +38,18 @@ export class FilteredSelectionExtension extends SelectionExtension {
 
   public setLockedObjectsGetter(getter: () => Set<string>): void {
     this.lockedObjectsGetter = getter
+  }
+
+  public setNonInteractiveObjectsGetter(getter: () => string[]): void {
+    this.nonInteractiveObjectsGetter = getter
+  }
+
+  private isNonInteractiveObject(id: string): boolean {
+    if (this.nonInteractiveObjectsGetter) {
+      const nonInteractiveIds = this.nonInteractiveObjectsGetter()
+      return nonInteractiveIds.includes(id)
+    }
+    return false
   }
 
   public on<T extends FilteredSelectionEvent>(
@@ -112,7 +125,7 @@ export class FilteredSelectionExtension extends SelectionExtension {
 
   protected onObjectClicked(selection: SelectionEvent | null) {
     console.log('🎯 FilteredSelectionExtension.onObjectClicked called with:', selection)
-    
+
     if (!selection) {
       console.log('🎯 No selection, calling super with null')
       super.onObjectClicked(selection)
@@ -147,6 +160,27 @@ export class FilteredSelectionExtension extends SelectionExtension {
       // If no valid hits, treat as empty selection
       super.onObjectClicked(null)
     }
+  }
+
+  protected onObjectDoubleClick(selection: SelectionEvent | null) {
+    console.log('🎯 FilteredSelectionExtension.onObjectDoubleClick called with:', selection)
+
+    if (!selection || !selection.hits || selection.hits.length === 0) {
+      super.onObjectDoubleClick(selection)
+      return
+    }
+
+    // check if any of the double-clicked objects are from non-interactive models
+    for (const hit of selection.hits) {
+      const objectId = hit.node.model.id
+      if (this.isNonInteractiveObject(objectId)) {
+        console.log('🚫 Preventing zoom on non-interactive object:', objectId)
+        return
+      }
+    }
+
+    // if all objects are interactive, allow normal double-click zoom
+    super.onObjectDoubleClick(selection)
   }
 
   protected onPointerMove(e: Vector2 & { event: Event }) {

--- a/src/powerbi-visual/src/plugins/viewer.ts
+++ b/src/powerbi-visual/src/plugins/viewer.ts
@@ -280,6 +280,9 @@ export class ViewerHandler {
       this.setViewMode(Number(store.defaultViewModeInFile))
     }
 
+    // sync the map to store filtering
+    store.setModelObjectsMap(this.modelObjectsMap)
+
     Tracker.dataLoaded({
       sourceHostApp: store.receiveInfo.sourceApplication,
       workspace_id: store.receiveInfo.workspaceId,

--- a/src/powerbi-visual/src/plugins/viewer.ts
+++ b/src/powerbi-visual/src/plugins/viewer.ts
@@ -179,8 +179,6 @@ export class ViewerHandler {
       const nonInteractiveObjectIds = this.getNonInteractiveObjectIds()
       const allVisibleIds = [...objectIds, ...nonInteractiveObjectIds]
 
-      console.log(`📊 Filtering: ${objectIds.length} selected + ${nonInteractiveObjectIds.length} non-interactive = ${allVisibleIds.length} total visible`)
-
       this.filteringState = this.filtering.isolateObjects(allVisibleIds, 'powerbi', true, ghost)
       if (zoom) {
         this.zoomObjects(objectIds, true)
@@ -193,8 +191,6 @@ export class ViewerHandler {
     if (objectIds) {
       const nonInteractiveObjectIds = this.getNonInteractiveObjectIds()
       const allVisibleIds = [...objectIds, ...nonInteractiveObjectIds]
-
-      console.log(`📊 Reset filter: ${objectIds.length} objects + ${nonInteractiveObjectIds.length} non-interactive = ${allVisibleIds.length} total visible`)
 
       this.isolateObjects(allVisibleIds, ghost)
       if (zoom) {
@@ -300,7 +296,6 @@ export class ViewerHandler {
         })
 
         this.modelObjectsMap.set(rootObjectId, objectIds)
-        console.log(`📦 Mapped ${objectIds.size} objects to root object: ${rootObjectId} (${modelMetadata[i].modelName})`)
       }
 
       // Since you are setting another camera position, maybe you want the second argument to false

--- a/src/powerbi-visual/src/store/visualStore.ts
+++ b/src/powerbi-visual/src/store/visualStore.ts
@@ -554,13 +554,13 @@ export const useVisualStore = defineStore('visualStore', () => {
     contextModeSettings.value = settings
   }
 
-  const setModelContextMode = (modelId: string, settings: ModelContextSettings) => {
-    contextModeSettings.value[modelId] = settings
+  const setModelContextMode = (rootObjectId: string, settings: ModelContextSettings) => {
+    contextModeSettings.value[rootObjectId] = settings
   }
 
-  const getModelContextSettings = (modelId: string): ModelContextSettings => {
+  const getModelContextSettings = (rootObjectId: string): ModelContextSettings => {
     // return existing settings or default to visible and unlocked
-    return contextModeSettings.value[modelId] || { visible: true, locked: false }
+    return contextModeSettings.value[rootObjectId] || { visible: true, locked: false }
   }
 
   const setModelMetadata = (metadata: ModelMetadata[]) => {

--- a/src/powerbi-visual/src/types.ts
+++ b/src/powerbi-visual/src/types.ts
@@ -21,6 +21,7 @@ export interface SpeckleDataInput {
 export interface ModelContextSettings {
   visible: boolean
   locked: boolean
+  interactive: boolean
 }
 
 export interface ContextModeSettings {

--- a/src/powerbi-visual/src/types.ts
+++ b/src/powerbi-visual/src/types.ts
@@ -24,10 +24,10 @@ export interface ModelContextSettings {
 }
 
 export interface ContextModeSettings {
-  [modelId: string]: ModelContextSettings
+  [rootObjectId: string]: ModelContextSettings
 }
 
 export interface ModelMetadata {
-  modelId: string
+  rootObjectId: string
   modelName: string
 }

--- a/src/powerbi-visual/src/types.ts
+++ b/src/powerbi-visual/src/types.ts
@@ -17,3 +17,17 @@ export interface SpeckleDataInput {
   objectTooltipData: Map<string, IViewerTooltip>
   isFromStore: boolean
 }
+
+export interface ModelContextSettings {
+  visible: boolean
+  locked: boolean
+}
+
+export interface ContextModeSettings {
+  [modelId: string]: ModelContextSettings
+}
+
+export interface ModelMetadata {
+  modelId: string
+  modelName: string
+}

--- a/src/powerbi-visual/src/utils/matrixViewUtils.ts
+++ b/src/powerbi-visual/src/utils/matrixViewUtils.ts
@@ -352,6 +352,19 @@ export async function processMatrixView(
       console.log('Desktop service unavailable - cannot retrieve credentials')
     }
 
+    // parse model metadata for federated models
+    if (id.includes(',')) {
+      const modelIds = id.split(',')
+      const metadata = modelIds.map((modelId) => {
+        return {
+          modelId: modelId,
+          modelName: modelId // TODO: use model name instead, this is just a placeholder for now
+        }
+      })
+      visualStore.setModelMetadata(metadata)
+      console.log('Federated model detected. Model metadata:', metadata)
+    }
+
     // Now get the data from visual store for Speckle API download
     const token = visualStore.receiveInfo?.token
     const serverUrl = visualStore.receiveInfo?.serverUrl

--- a/src/powerbi-visual/src/utils/matrixViewUtils.ts
+++ b/src/powerbi-visual/src/utils/matrixViewUtils.ts
@@ -354,11 +354,11 @@ export async function processMatrixView(
 
     // parse model metadata for federated models
     if (id.includes(',')) {
-      const modelIds = id.split(',')
-      const metadata = modelIds.map((modelId) => {
+      const rootObjectIds = id.split(',')
+      const metadata = rootObjectIds.map((rootObjectId) => {
         return {
-          modelId: modelId,
-          modelName: modelId // TODO: use model name instead, this is just a placeholder for now
+          rootObjectId: rootObjectId,
+          modelName: rootObjectId // placeholder, will be replaced with actual name from root object
         }
       })
       visualStore.setModelMetadata(metadata)

--- a/src/powerbi-visual/src/utils/matrixViewUtils.ts
+++ b/src/powerbi-visual/src/utils/matrixViewUtils.ts
@@ -471,7 +471,13 @@ export async function processMatrixView(
         const processedObjectIdLevels = processObjectIdLevel(obj, host, matrixView)
 
         objectIds.push(processedObjectIdLevels.id)
-        onSelectionPair(processedObjectIdLevels.id, processedObjectIdLevels.selectionId)
+
+        // note: on first load, modelObjectsMap may be empty, so we default to registering all objects
+        // when user toggles interactive state, refreshHostData with filtering
+        if (visualStore.isObjectInteractive(processedObjectIdLevels.id)) {
+          onSelectionPair(processedObjectIdLevels.id, processedObjectIdLevels.selectionId)
+        }
+
         if (processedObjectIdLevels.shouldSelect) selectedIds.push(processedObjectIdLevels.id)
         if (processedObjectIdLevels.shouldColor) {
           colorGroup.objectIds.push(processedObjectIdLevels.id)
@@ -506,7 +512,13 @@ export async function processMatrixView(
       }
 
       objectIds.push(processedObjectIdLevels.id)
-      onSelectionPair(processedObjectIdLevels.id, processedObjectIdLevels.selectionId)
+
+      // note: on first load, modelObjectsMap may be empty, so we default to registering all objects
+      // when user toggles interactive state, refreshHostData with filtering
+      if (visualStore.isObjectInteractive(processedObjectIdLevels.id)) {
+        onSelectionPair(processedObjectIdLevels.id, processedObjectIdLevels.selectionId)
+      }
+
       if (processedObjectIdLevels.shouldSelect) {
         selectedIds.push(processedObjectIdLevels.id)
       }

--- a/src/powerbi-visual/src/visual.ts
+++ b/src/powerbi-visual/src/visual.ts
@@ -7,7 +7,7 @@ import App from './App.vue'
 import VueTippy from 'vue-tippy'
 import { selectionHandlerKey, tooltipHandlerKey } from 'src/injectionKeys'
 
-import { SpeckleDataInput } from './types'
+import { SpeckleDataInput, ContextModeSettings } from './types'
 import { processMatrixView, ReceiveInfo, validateMatrixView } from './utils/matrixViewUtils'
 import { SpeckleVisualSettingsModel } from './settings/visualSettingsModel'
 import { unzipModelObjects } from './utils/compression'
@@ -254,11 +254,29 @@ export class Visual implements IVisual {
                 console.warn(error)
                 console.log('missing stored receive info')
               }
+
+              // load context mode settings from file
+              try {
+                const contextModeFromFile = JSON.parse(
+                  options.dataViews[0].metadata.objects.contextMode?.settings as string
+                ) as ContextModeSettings
+                visualStore.setContextModeSettings(contextModeFromFile)
+                console.log('Loaded context mode settings from file:', contextModeFromFile)
+              } catch (error) {
+                console.log('No stored context mode settings found')
+              }
             }
 
             // Check for internalized data
             const internalizedData = options.dataViews[0].metadata.objects?.storedData
               ?.speckleObjects as string
+
+            // reset selection handler if we're reprocessing data (not first load)
+            // this ensures only interactive objects get registered
+            if (visualStore.isViewerObjectsLoaded && visualStore.getModelObjectsMap().size > 0) {
+              console.log('🔄 Resetting selection handler for interactive mode update')
+              this.selectionHandler.reset()
+            }
 
             const input = await processMatrixView(
               matrixView,

--- a/src/powerbi-visual/src/visual.ts
+++ b/src/powerbi-visual/src/visual.ts
@@ -274,7 +274,6 @@ export class Visual implements IVisual {
             // reset selection handler if we're reprocessing data (not first load)
             // this ensures only interactive objects get registered
             if (visualStore.isViewerObjectsLoaded && visualStore.getModelObjectsMap().size > 0) {
-              console.log('🔄 Resetting selection handler for interactive mode update')
               this.selectionHandler.reset()
             }
 


### PR DESCRIPTION
Implements a context mode feature that allows users to add certain models as 'context' into their visual. To add a context model, user can federate the context model on their main model and load it into the Power BI visual. After we detect the model is a federated model, a new button will be appear on the list.

<img width="573" height="636" alt="image" src="https://github.com/user-attachments/assets/cd47f6d2-5e28-424c-92a7-1a3786035a88" />


There will be three toggle for every model -> visibility, lock, interactivity
- **Visibility Toggle**: Show/hide models in the 3D viewer
- **Model Lock Toggle**: Prevent selection of objects in specific models
- **Model Interactivity Toggle**: Control whether a model participates in cross-filtering
- **Settings Persistence**: All context mode settings are saved to the file

Related to -> https://linear.app/speckle/issue/CNX-2636/add-context-mode-for-models

Testing flow ->
 - Load a federated model (multiple models in one visual)
 - Verify Context Mode menu appears in viewer controls
  - Test visibility toggle - model should show/hide
  - Test lock toggle - locked models should not be selectable
  - Test interactive toggle - non-interactive models should:
    - Remain visible during PowerBI cross-filtering
    - Not participate in selection-based filtering
    - Not zoom on double-click
  - Verify settings persist after saving and reopening the PowerBI file
  - Test with single model - Context Mode menu should not appear
