### PR TITLE
fix(visual): deselecting elements doesn't reset filters for other visuals

### DIFF
--- a/src/powerbi-visual/src/components/ViewerWrapper.vue
+++ b/src/powerbi-visual/src/components/ViewerWrapper.vue
@@ -195,7 +195,15 @@ async function handleObjectClicked(hit: any, isMultiSelect: boolean, mouseEvent?
     const ids = selection.map((s) => s.id)
     await viewerHandler.selectObjects(ids)
   } else {
-    visualStore.setPostClickSkipNeeded(true)
+    // Only set skip flag if this visual has active selections to clear.
+    // When selectionManager.clear() is called with no active selection,
+    // Power BI won't send a reaction update, so there's nothing to skip.
+    // Setting the flag unconditionally would cause it to eat the NEXT
+    // legitimate Data update (e.g., adding Color By input).
+    const hasActiveSelection = selectionHandler.getCurrentSelection().length > 0
+    if (hasActiveSelection) {
+      visualStore.setPostClickSkipNeeded(true)
+    }
     tooltipHandler.hide()
     if (!isMultiSelect) {
       selectionHandler.clear()

--- a/src/powerbi-visual/src/components/ViewerWrapper.vue
+++ b/src/powerbi-visual/src/components/ViewerWrapper.vue
@@ -195,7 +195,7 @@ async function handleObjectClicked(hit: any, isMultiSelect: boolean, mouseEvent?
     const ids = selection.map((s) => s.id)
     await viewerHandler.selectObjects(ids)
   } else {
-    visualStore.setPostClickSkipNeeded(false)
+    visualStore.setPostClickSkipNeeded(true)
     tooltipHandler.hide()
     if (!isMultiSelect) {
       selectionHandler.clear()

--- a/src/powerbi-visual/src/extensions/FilteredSelectionExtension.ts
+++ b/src/powerbi-visual/src/extensions/FilteredSelectionExtension.ts
@@ -87,6 +87,7 @@ export class FilteredSelectionExtension extends SelectionExtension {
     if (!selection) {
       console.log('🎯 No selection, calling super with null')
       super.onObjectClicked(selection)
+      this.emit(FilteredSelectionEvent.FilteredObjectClicked, null)
       return
     }
 
@@ -117,6 +118,7 @@ export class FilteredSelectionExtension extends SelectionExtension {
     } else {
       // If no valid hits, treat as empty selection
       super.onObjectClicked(null)
+      this.emit(FilteredSelectionEvent.FilteredObjectClicked, null)
     }
   }
 


### PR DESCRIPTION
When clicking empty space to deselect, other visuals in the report wouldn't reset their filters, This PR addresses that.
Previously, the deselection event was swallowed in FilteredSelectionExtension and never reached selectionManager.clear()
Addresses following community report:
https://speckle.community/t/single-selection-elements-in-power-bi/21754

Before

https://github.com/user-attachments/assets/399e85c6-ec88-4a8a-abb0-ba56a7852047

After

https://github.com/user-attachments/assets/98663643-7b73-4983-a621-470ecf91d713
