### PR TITLE
fix(visual): visual doesnt reset after removing all inputs

### DIFF
--- a/src/powerbi-visual/src/store/visualStore.ts
+++ b/src/powerbi-visual/src/store/visualStore.ts
@@ -435,6 +435,12 @@ export const useVisualStore = defineStore('visualStore', () => {
 
   const clearDataInput = () => (dataInput.value = null)
 
+  const resetViewerState = () => {
+    setViewerReadyToLoad(false)
+    clearDataInput()
+    lastLoadedRootObjectId.value = undefined
+    isViewerObjectsLoaded.value = false
+  }
 
   const setViewerReadyToLoad = (newValue: boolean) => (isViewerReadyToLoad.value = newValue)
 
@@ -652,6 +658,7 @@ export const useVisualStore = defineStore('visualStore', () => {
     setLoadingProgress,
     clearLoadingProgress,
     setIsLoadingFromFile,
+    resetViewerState,
     resetFilters,
     downloadLatestVersion,
     handleObjectsLoadedComplete,

--- a/src/powerbi-visual/src/visual.ts
+++ b/src/powerbi-visual/src/visual.ts
@@ -68,14 +68,6 @@ export class Visual implements IVisual {
     this.selectionHandler.clear()
   }
 
-  private resetViewerState() {
-    const visualStore = useVisualStore()
-    visualStore.setViewerReadyToLoad(false)
-    visualStore.clearDataInput()
-    visualStore.lastLoadedRootObjectId = undefined
-    visualStore.isViewerObjectsLoaded = false
-  }
-
   public async update(options: VisualUpdateOptions) {
     const visualStore = useVisualStore()
     if (visualStore.commonError) {
@@ -159,7 +151,7 @@ export class Visual implements IVisual {
 
       if (!validationResult.rootObjectId) {
         console.log('🔄 Root object ID removed - resetting viewer state')
-        this.resetViewerState()
+        visualStore.resetViewerState()
         return
       }
 
@@ -353,7 +345,7 @@ export class Visual implements IVisual {
         colorBy: false,
         tooltipData: false
       })
-      this.resetViewerState()
+      visualStore.resetViewerState()
       return
     }
   }

--- a/src/powerbi-visual/src/visual.ts
+++ b/src/powerbi-visual/src/visual.ts
@@ -78,12 +78,24 @@ export class Visual implements IVisual {
     if (visualStore.postFileSaveSkipNeeded) {
       visualStore.setPostFileSaveSkipNeeded(false)
       console.log('Skipping unneccessary update function after file save.')
+      try {
+        const matrixView = options.dataViews[0]?.matrix
+        if (matrixView) {
+          visualStore.setFieldInputState(validateMatrixView(options))
+        }
+      } catch (e) { /* ignore - inputs not ready */ }
       return
     }
 
     if (visualStore.postClickSkipNeeded) {
       visualStore.setPostClickSkipNeeded(false)
       console.log('Skipping unneccessary update function canvas click.')
+      try {
+        const matrixView = options.dataViews[0]?.matrix
+        if (matrixView) {
+          visualStore.setFieldInputState(validateMatrixView(options))
+        }
+      } catch (e) { /* ignore - inputs not ready */ }
       return
     }
 

--- a/src/powerbi-visual/src/visual.ts
+++ b/src/powerbi-visual/src/visual.ts
@@ -153,6 +153,7 @@ export class Visual implements IVisual {
       console.log('❓Field inputs', validationResult)
 
       if (!validationResult.rootObjectId) {
+        console.log('🔄 Root object ID removed - resetting viewer state')
         visualStore.setViewerReadyToLoad(false)
         visualStore.clearDataInput()
         visualStore.lastLoadedRootObjectId = undefined

--- a/src/powerbi-visual/src/visual.ts
+++ b/src/powerbi-visual/src/visual.ts
@@ -136,6 +136,14 @@ export class Visual implements IVisual {
       visualStore.setFieldInputState(validationResult)
       console.log('❓Field inputs', validationResult)
 
+      if (!validationResult.rootObjectId) {
+        visualStore.setViewerReadyToLoad(false)
+        visualStore.clearDataInput()
+        visualStore.lastLoadedRootObjectId = undefined
+        visualStore.isViewerObjectsLoaded = false
+        return
+      }
+
       switch (options.type) {
         case powerbi.VisualUpdateType.Resize:
         case powerbi.VisualUpdateType.ResizeEnd:
@@ -326,6 +334,10 @@ export class Visual implements IVisual {
         colorBy: false,
         tooltipData: false
       })
+      visualStore.setViewerReadyToLoad(false)
+      visualStore.clearDataInput()
+      visualStore.lastLoadedRootObjectId = undefined
+      visualStore.isViewerObjectsLoaded = false
       return
     }
   }

--- a/src/powerbi-visual/src/visual.ts
+++ b/src/powerbi-visual/src/visual.ts
@@ -83,9 +83,7 @@ export class Visual implements IVisual {
       visualStore.setViewerReadyToLoad(false)
     }
 
-    if (visualStore.postFileSaveSkipNeeded) {
-      visualStore.setPostFileSaveSkipNeeded(false)
-      console.log('Skipping unneccessary update function after file save.')
+    const tryUpdateFieldInputState = () => {
       try {
         const matrixView = options.dataViews[0]?.matrix
         if (matrixView) {
@@ -94,20 +92,19 @@ export class Visual implements IVisual {
       } catch (e) {
         console.warn('Failed to update field input state during skip path:', (e as Error).message)
       }
+    }
+
+    if (visualStore.postFileSaveSkipNeeded) {
+      visualStore.setPostFileSaveSkipNeeded(false)
+      console.log('Skipping unneccessary update function after file save.')
+      tryUpdateFieldInputState()
       return
     }
 
     if (visualStore.postClickSkipNeeded) {
       visualStore.setPostClickSkipNeeded(false)
       console.log('Skipping unneccessary update function canvas click.')
-      try {
-        const matrixView = options.dataViews[0]?.matrix
-        if (matrixView) {
-          visualStore.setFieldInputState(validateMatrixView(options))
-        }
-      } catch (e) {
-        console.warn('Failed to update field input state during skip path:', (e as Error).message)
-      }
+      tryUpdateFieldInputState()
       return
     }
 

--- a/src/powerbi-visual/src/visual.ts
+++ b/src/powerbi-visual/src/visual.ts
@@ -68,6 +68,14 @@ export class Visual implements IVisual {
     this.selectionHandler.clear()
   }
 
+  private resetViewerState() {
+    const visualStore = useVisualStore()
+    visualStore.setViewerReadyToLoad(false)
+    visualStore.clearDataInput()
+    visualStore.lastLoadedRootObjectId = undefined
+    visualStore.isViewerObjectsLoaded = false
+  }
+
   public async update(options: VisualUpdateOptions) {
     const visualStore = useVisualStore()
     if (visualStore.commonError) {
@@ -154,10 +162,7 @@ export class Visual implements IVisual {
 
       if (!validationResult.rootObjectId) {
         console.log('🔄 Root object ID removed - resetting viewer state')
-        visualStore.setViewerReadyToLoad(false)
-        visualStore.clearDataInput()
-        visualStore.lastLoadedRootObjectId = undefined
-        visualStore.isViewerObjectsLoaded = false
+        this.resetViewerState()
         return
       }
 
@@ -351,10 +356,7 @@ export class Visual implements IVisual {
         colorBy: false,
         tooltipData: false
       })
-      visualStore.setViewerReadyToLoad(false)
-      visualStore.clearDataInput()
-      visualStore.lastLoadedRootObjectId = undefined
-      visualStore.isViewerObjectsLoaded = false
+      this.resetViewerState()
       return
     }
   }

--- a/src/powerbi-visual/src/visual.ts
+++ b/src/powerbi-visual/src/visual.ts
@@ -83,7 +83,9 @@ export class Visual implements IVisual {
         if (matrixView) {
           visualStore.setFieldInputState(validateMatrixView(options))
         }
-      } catch (e) { /* ignore - inputs not ready */ }
+      } catch (e) {
+        console.warn('Failed to update field input state during skip path:', (e as Error).message)
+      }
       return
     }
 
@@ -95,7 +97,9 @@ export class Visual implements IVisual {
         if (matrixView) {
           visualStore.setFieldInputState(validateMatrixView(options))
         }
-      } catch (e) { /* ignore - inputs not ready */ }
+      } catch (e) {
+        console.warn('Failed to update field input state during skip path:', (e as Error).message)
+      }
       return
     }
 


### PR DESCRIPTION
Fixes the issue where the 3D visual fails to reset when all input fields are removed.

### Changes

**1. Reset on Empty Input**
Added a check in the `update()` method to detect when the root object ID is removed. When this occurs, the viewer state is now properly reset and returns early to prevent unnecessary processing.

```typescript
if (!validationResult.rootObjectId) {
  console.log('🔄 Root object ID removed - resetting viewer state')
  this.resetViewerState()
  return
}
```

**2. Code Refactoring**
Extracted the duplicated 4-line reset sequence into a private `resetViewerState()` method. This was previously repeated in three locations (lines 151-155, 349-352, and the outer catch block).

**3. Field Input Validation on Skip Paths**
Added field input state validation during both `postFileSaveSkip` and `postClickSkip` paths. This ensures the field validation state stays synchronized even when update cycles are intentionally skipped, wrapped in try-catch to prevent failures from blocking the skip logic.

**4. Error Handling**
Replaced an empty catch block with proper error logging in the skip path validation.

### Before

https://github.com/user-attachments/assets/b1257829-c2fb-4bec-84bf-f25dc70afcfd

### After

https://github.com/user-attachments/assets/88059d0d-eb73-45ba-9165-9ef0fd7dae6a