### PR TITLE
feat: move from embed token api to share token api

### DIFF
--- a/src/powerbi-data-connector/speckle/GetByUrl.pqm
+++ b/src/powerbi-data-connector/speckle/GetByUrl.pqm
@@ -66,7 +66,8 @@
             powerfulToken,
             {"profile:read", "streams:read", "users:read"},
             parsedUrl[projectId],
-            parsedUrl[baseUrl]
+            parsedUrl[baseUrl],
+            parsedUrl[resourceIdString]
         ),
 
         // throw error if token exchange failed - do NOT use powerful token as fallback

--- a/src/powerbi-data-connector/speckle/api/ExchangeToken.pqm
+++ b/src/powerbi-data-connector/speckle/api/ExchangeToken.pqm
@@ -1,9 +1,6 @@
 // Function to exchange powerful token for weak limited token
 (powerfulToken as text, scopes as list, projectId as text, serverUrl as text, optional resourceIdString as text) as record =>
     let
-        // Import the parser function for URL handling
-        Parser = Extension.LoadFunction("Parser.pqm"),
-
         // Helper function to load .pqm modules dynamically
         Extension.LoadFunction = (fileName as text) =>
             let
@@ -39,42 +36,41 @@
         else
             serverUrl & "/",
 
-        // New token exchange mutation
-        NewGraphQLMutation = if resourceIdString <> null then "
-            mutation {
-                sharingMutations {
-                    createEmbedShareToken(input: {
-                        projectId: """ & projectId & """,
-                        resourceIdString: """ & resourceIdString & """
-                    }) {
-                        token
-                    }
+        // New Share Token API mutation with variables
+        NewGraphQLQuery = "mutation CreateEmbedShareToken($input: CreateEmbedShareTokenInput!) {
+            sharingMutations {
+                createEmbedShareToken(input: $input) {
+                    token
                 }
-            }"
-        else null,
+            }
+        }",
+        NewGraphQLVariables = [
+            input = [
+                projectId = projectId,
+                resourceIdString = resourceIdString
+            ]
+        ],
 
-        // Legacy token creation mutation
+        // Legacy apiTokenCreate mutation with variables
         TokenLifespanMs = 10 * 365 * 24 * 3600 * 1000,
         TokenName = "Limited Power BI Visual Token - " & DateTime.ToText(DateTime.LocalNow(), "yyyy-MM-dd HH:mm"),
-        ScopesArray = Text.Combine(
-            List.Transform(scopes, each """" & _ & """"),
-            ", "
-        ),
-        LegacyGraphQLMutation = "
-            mutation {
-                apiTokenCreate(token: {
-                    name: """ & TokenName & """,
-                    scopes: [" & ScopesArray & "],
-                    lifespan: " & Number.ToText(TokenLifespanMs) & ",
-                    limitResources: [{
-                        type: project,
-                        id: """ & projectId & """
-                    }]
-                })
-            }",
+        LegacyGraphQLQuery = "mutation CreateApiToken($token: ApiTokenCreateInput!) {
+            apiTokenCreate(token: $token)
+        }",
+        LegacyGraphQLVariables = [
+            token = [
+                name = TokenName,
+                scopes = scopes,
+                lifespan = TokenLifespanMs,
+                limitResources = {[
+                    type = "project",
+                    id = projectId
+                ]}
+            ]
+        ],
 
-        // Helper for execution
-        ExecuteGraphQL = (mutation as text, extractToken as function) =>
+        // Helper: execute a GraphQL query with variables and extract token
+        ExecuteGraphQL = (query as text, variables as record, extractToken as function) =>
             let
                 Response = Web.Contents(
                     NormalizedServerUrl & "graphql",
@@ -84,7 +80,10 @@
                             #"Content-Type" = "application/json",
                             #"Authorization" = "Bearer " & powerfulToken
                         ],
-                        Content = Json.FromValue([query = mutation]),
+                        Content = Json.FromValue([
+                            query = query,
+                            variables = variables
+                        ]),
                         ManualStatusHandling = {400, 401, 403, 404, 500, 502, 503, 504},
                         Timeout = #duration(0, 0, 0, 10)
                     ]
@@ -113,9 +112,10 @@
             [Success = false, Token = null, ErrorMessage = ValidationError]
         else
             let
-                newResult = if NewGraphQLMutation <> null then
+                newResult = if resourceIdString <> null then
                     try ExecuteGraphQL(
-                        NewGraphQLMutation,
+                        NewGraphQLQuery,
+                        NewGraphQLVariables,
                         each [data][sharingMutations][createEmbedShareToken][token]
                     ) otherwise [Success = false, Token = null, ErrorMessage = "New API request failed"]
                 else
@@ -125,7 +125,8 @@
                     newResult
                 else
                     try ExecuteGraphQL(
-                        LegacyGraphQLMutation,
+                        LegacyGraphQLQuery,
+                        LegacyGraphQLVariables,
                         each [data][apiTokenCreate]
                     ) otherwise [Success = false, Token = null, ErrorMessage = "Token exchange request failed"]
             in

--- a/src/powerbi-data-connector/speckle/api/ExchangeToken.pqm
+++ b/src/powerbi-data-connector/speckle/api/ExchangeToken.pqm
@@ -1,5 +1,5 @@
 // Function to exchange powerful token for weak limited token
-(powerfulToken as text, scopes as list, projectId as text, serverUrl as text) as record =>
+(powerfulToken as text, scopes as list, projectId as text, serverUrl as text, optional resourceIdString as text) as record =>
     let
         // Import the parser function for URL handling
         Parser = Extension.LoadFunction("Parser.pqm"),
@@ -33,20 +33,34 @@
         else
             null,
 
-        // Token lifetime: 10 years (315,360,000,000 milliseconds)
+        // Ensure serverUrl ends with /
+        NormalizedServerUrl = if Text.End(serverUrl, 1) = "/" then
+            serverUrl
+        else
+            serverUrl & "/",
+
+        // New token exchange mutation
+        NewGraphQLMutation = if resourceIdString <> null then "
+            mutation {
+                sharingMutations {
+                    createEmbedShareToken(input: {
+                        projectId: """ & projectId & """,
+                        resourceIdString: """ & resourceIdString & """
+                    }) {
+                        token
+                    }
+                }
+            }"
+        else null,
+
+        // Legacy token creation mutation
         TokenLifespanMs = 10 * 365 * 24 * 3600 * 1000,
-
-        // Generate token name with timestamp
         TokenName = "Limited Power BI Visual Token - " & DateTime.ToText(DateTime.LocalNow(), "yyyy-MM-dd HH:mm"),
-
-        // Build scopes array string for GraphQL (e.g., ["profile:read", "streams:read"])
         ScopesArray = Text.Combine(
             List.Transform(scopes, each """" & _ & """"),
             ", "
         ),
-
-        // Build GraphQL mutation
-        GraphQLMutation = "
+        LegacyGraphQLMutation = "
             mutation {
                 apiTokenCreate(token: {
                     name: """ & TokenName & """,
@@ -59,88 +73,62 @@
                 })
             }",
 
-        // Execute token exchange if validation passes
+        // Helper for execution
+        ExecuteGraphQL = (mutation as text, extractToken as function) =>
+            let
+                Response = Web.Contents(
+                    NormalizedServerUrl & "graphql",
+                    [
+                        Headers = [
+                            #"Method" = "POST",
+                            #"Content-Type" = "application/json",
+                            #"Authorization" = "Bearer " & powerfulToken
+                        ],
+                        Content = Json.FromValue([query = mutation]),
+                        ManualStatusHandling = {400, 401, 403, 404, 500, 502, 503, 504},
+                        Timeout = #duration(0, 0, 0, 10)
+                    ]
+                ),
+                StatusCode = Value.Metadata(Response)[Response.Status],
+                JsonResponse = if StatusCode >= 200 and StatusCode < 300 then
+                    Json.Document(Response)
+                else
+                    null,
+                HasErrors = JsonResponse <> null and Record.HasFields(JsonResponse, {"errors"}),
+                Token = if JsonResponse <> null and not HasErrors then
+                    try extractToken(JsonResponse) otherwise null
+                else
+                    null,
+                ErrorMsg = if HasErrors then
+                    try JsonResponse[errors]{0}[message] otherwise "GraphQL mutation failed"
+                else if JsonResponse = null then
+                    "Request failed with status " & Number.ToText(StatusCode)
+                else
+                    null
+            in
+                [Success = Token <> null, Token = Token, ErrorMessage = ErrorMsg],
+
+        // Try new API first, fall back to legacy
         Result = if ValidationError <> null then
-            [
-                Success = false,
-                Token = null,
-                ErrorMessage = ValidationError
-            ]
+            [Success = false, Token = null, ErrorMessage = ValidationError]
         else
-            try
-                let
-                    // Ensure serverUrl ends with /
-                    NormalizedServerUrl = if Text.End(serverUrl, 1) = "/" then
-                        serverUrl
-                    else
-                        serverUrl & "/",
+            let
+                newResult = if NewGraphQLMutation <> null then
+                    try ExecuteGraphQL(
+                        NewGraphQLMutation,
+                        each [data][sharingMutations][createEmbedShareToken][token]
+                    ) otherwise [Success = false, Token = null, ErrorMessage = "New API request failed"]
+                else
+                    [Success = false, Token = null, ErrorMessage = null],
 
-                    // Make GraphQL request
-                    Response = Web.Contents(
-                        NormalizedServerUrl & "graphql",
-                        [
-                            Headers = [
-                                #"Method" = "POST",
-                                #"Content-Type" = "application/json",
-                                #"Authorization" = "Bearer " & powerfulToken
-                            ],
-                            Content = Json.FromValue([
-                                query = GraphQLMutation
-                            ]),
-                            ManualStatusHandling = {400, 401, 403, 404, 500, 502, 503, 504},
-                            Timeout = #duration(0, 0, 0, 10)
-                        ]
-                    ),
-
-                    StatusCode = Value.Metadata(Response)[Response.Status],
-
-                    // Parse response if successful
-                    ParsedResult = if StatusCode >= 200 and StatusCode < 300 then
-                        let
-                            JsonResponse = Json.Document(Response),
-
-                            // Check for GraphQL errors
-                            HasErrors = Record.HasFields(JsonResponse, {"errors"}),
-
-                            // Extract token from response
-                            WeakToken = if not HasErrors then
-                                JsonResponse[data][apiTokenCreate]
-                            else
-                                null,
-
-                            ErrorMsg = if HasErrors then
-                                try
-                                    JsonResponse[errors]{0}[message]
-                                otherwise
-                                    "GraphQL mutation failed with unknown error"
-                            else
-                                null
-                        in
-                            if WeakToken <> null then
-                                [
-                                    Success = true,
-                                    Token = WeakToken,
-                                    ErrorMessage = null
-                                ]
-                            else
-                                [
-                                    Success = false,
-                                    Token = null,
-                                    ErrorMessage = ErrorMsg
-                                ]
-                    else
-                        [
-                            Success = false,
-                            Token = null,
-                            ErrorMessage = "GraphQL request failed with status " & Number.ToText(StatusCode)
-                        ]
-                in
-                    ParsedResult
-            otherwise
-                [
-                    Success = false,
-                    Token = null,
-                    ErrorMessage = "Token exchange request failed with exception"
-                ]
+                finalResult = if newResult[Success] then
+                    newResult
+                else
+                    try ExecuteGraphQL(
+                        LegacyGraphQLMutation,
+                        each [data][apiTokenCreate]
+                    ) otherwise [Success = false, Token = null, ErrorMessage = "Token exchange request failed"]
+            in
+                finalResult
     in
         Result

--- a/src/powerbi-data-connector/speckle/api/Parser.pqm
+++ b/src/powerbi-data-connector/speckle/api/Parser.pqm
@@ -54,5 +54,6 @@
                 modelId = if isFederated then null else processedModels{0}[modelId],
                 versionId = if isFederated then null else processedModels{0}[versionId],
                 isFederated = isFederated,
-                federatedModels = if isFederated then processedModels else null
+                federatedModels = if isFederated then processedModels else null,
+                resourceIdString = rawModelSegment
             ]

--- a/src/powerbi-data-connector/speckle/api/SendToServer.pqm
+++ b/src/powerbi-data-connector/speckle/api/SendToServer.pqm
@@ -33,7 +33,8 @@
             powerfulToken,
             {"profile:read", "streams:read", "users:read"},
             parsedUrl[projectId],
-            parsedUrl[baseUrl]
+            parsedUrl[baseUrl],
+            parsedUrl[resourceIdString]
         ),
 
         // throw error if token exchange failed - do NOT use powerful token as fallback


### PR DESCRIPTION
Migrate token exchange from `apiTokenCreate` to the new `createEmbedShareToken`. Data side now tries to exchange token with the new API first and automatically falls back to the legacy mutation for older servers. 

Tested with multiple models including federated models. 