### PR TITLE
feat(connector): support models/all convention

### DIFF
--- a/src/powerbi-data-connector/Speckle.pq
+++ b/src/powerbi-data-connector/Speckle.pq
@@ -221,7 +221,11 @@ shared Speckle.GetByUrl = Value.ReplaceType(
             - Model URL: Gets the latest version of the specified model#(lf)
               (e.g., 'https://app.speckle.systems/projects/PROJECT_ID/models/MODEL_ID')#(lf)
             - Version URL: Gets a specific version from the project#(lf)
-              (e.g., 'https://app.speckle.systems/projects/PROJECT_ID/models/MODEL_ID@VERSION_ID')"
+              (e.g., 'https://app.speckle.systems/projects/PROJECT_ID/models/MODEL_ID@VERSION_ID')#(lf)
+            - Federated Model URL: Gets multiple models from the project#(lf)
+              (e.g., 'https://app.speckle.systems/projects/PROJECT_ID/models/MODEL_ID1,MODEL_ID2')#(lf)
+            - Project-Wide Model Load URL: Resolves the project's flat model collection during refresh#(lf)
+              (e.g., 'https://app.speckle.systems/projects/PROJECT_ID/models/all')"
     ]
 );
 

--- a/src/powerbi-data-connector/speckle/GetByUrl.pqm
+++ b/src/powerbi-data-connector/speckle/GetByUrl.pqm
@@ -15,6 +15,7 @@
         GetVersion = Extension.LoadFunction("GetVersion.pqm"),
         GetWorkspace = Extension.LoadFunction("GetWorkspace.pqm"),
         MarkReceived = Extension.LoadFunction("MarkReceived.pqm"),
+        ProjectModels = Extension.LoadFunction("Project.Models.pqm"),
 
         // the logic for importing functions from other files
         Extension.LoadFunction = (fileName as text) =>
@@ -33,11 +34,51 @@
                             Detail = [File = fileName, Error = e]
                         ],
 
-        // parse the URL to determine if it's a federated model
+        ProjectWideModelLimit = 10000,
+
+        // parse the URL to determine load shape
         parsedUrl = Parser(url),
 
+        // project-wide model load is expanded before token exchange and loading
+        projectWideModelIds = if parsedUrl[isProjectWideModelLoad] then
+            ProjectModels(parsedUrl[baseUrl], parsedUrl[projectId], ProjectWideModelLimit)
+        else
+            null,
+
+        expandedResourceIdString = if parsedUrl[isProjectWideModelLoad] then
+            Text.Combine(projectWideModelIds, ",")
+        else
+            parsedUrl[resourceIdString],
+
+        effectiveUrl = if parsedUrl[isProjectWideModelLoad] then
+            Text.Combine({
+                parsedUrl[baseUrl],
+                "/projects/",
+                parsedUrl[projectId],
+                "/models/",
+                expandedResourceIdString
+            })
+        else
+            url,
+
+        effectiveParsedUrl = if parsedUrl[isProjectWideModelLoad] and expandedResourceIdString = "" then
+            [
+                baseUrl = parsedUrl[baseUrl],
+                projectId = parsedUrl[projectId],
+                modelId = "",
+                versionId = null,
+                isFederated = false,
+                isProjectWideModelLoad = false,
+                federatedModels = null,
+                resourceIdString = expandedResourceIdString
+            ]
+        else
+            Parser(effectiveUrl),
+
+        metadataUrl = if parsedUrl[isProjectWideModelLoad] then url else effectiveUrl,
+
         // check if user has permission to load the model
-        permissionCheck = CheckPermissions(url),
+        permissionCheck = CheckPermissions(metadataUrl),
 
         // assert that permission check returned a valid result
         permissionAssert = if not Record.HasFields(permissionCheck, {"authorized", "code", "message"}) then
@@ -55,19 +96,19 @@
             null,
 
         // get user info, connector version, and workspace info for encoding
-        userInfo = GetUser(url),
+        userInfo = GetUser(metadataUrl),
         powerfulToken = userInfo[Token],
         userEmail = userInfo[UserEmail],
         connectorVersion = GetVersion(),
-        workspaceInfo = GetWorkspace(url),
+        workspaceInfo = GetWorkspace(metadataUrl),
 
         // exchange powerful token for weak token with limited scopes
         tokenExchangeResult = ExchangeToken(
             powerfulToken,
             {"profile:read", "streams:read", "users:read"},
-            parsedUrl[projectId],
-            parsedUrl[baseUrl],
-            parsedUrl[resourceIdString]
+            effectiveParsedUrl[projectId],
+            effectiveParsedUrl[baseUrl],
+            effectiveParsedUrl[resourceIdString]
         ),
 
         // throw error if token exchange failed - do NOT use powerful token as fallback
@@ -80,21 +121,21 @@
                 Message.Parameters = {tokenExchangeResult[ErrorMessage]},
                 Detail = [
                     ErrorMessage = tokenExchangeResult[ErrorMessage],
-                    ProjectId = parsedUrl[projectId],
-                    ServerUrl = parsedUrl[baseUrl]
+                    ProjectId = effectiveParsedUrl[projectId],
+                    ServerUrl = effectiveParsedUrl[baseUrl]
                 ]
             ],
             
         // only proceed if user has permisson to load
         results = if permissionCheck[authorized] then
-            if parsedUrl[isFederated] = true then
+            if effectiveParsedUrl[isFederated] = true then
                 // process each model in the federation
                 let
                     modelsData = List.Transform(
-                        parsedUrl[federatedModels],
+                        effectiveParsedUrl[federatedModels],
                         each ProcessSingleModel(
-                            parsedUrl[baseUrl],
-                            parsedUrl[projectId],
+                            effectiveParsedUrl[baseUrl],
+                            effectiveParsedUrl[projectId],
                             [modelId],
                             [versionId]
                         )
@@ -142,24 +183,24 @@
                 // use existing functionality for single models
                 let
                     // get model info
-                    modelInfo = GetModel(url),
+                    modelInfo = GetModel(effectiveUrl),
                     modelName = modelInfo[modelName],
                     rootObjectId = modelInfo[rootObjectId],
                     sourceApplication = modelInfo[sourceApplication],
                     versionId = modelInfo[versionId],
 
                     // mark version as received
-                    markReceivedResult = MarkReceived(powerfulToken, versionId, parsedUrl[projectId], parsedUrl[baseUrl]),
+                    markReceivedResult = MarkReceived(powerfulToken, versionId, effectiveParsedUrl[projectId], effectiveParsedUrl[baseUrl]),
 
                     // get structured data
-                    structuredData = GetStructuredData(url),
+                    structuredData = GetStructuredData(effectiveUrl),
 
                     // build userInfoData record for this model
                     userInfoData = [
                         rootObjectId = rootObjectId,
-                        server = parsedUrl[baseUrl],
+                        server = effectiveParsedUrl[baseUrl],
                         email = userEmail,
-                        projectId = parsedUrl[projectId],
+                        projectId = effectiveParsedUrl[projectId],
                         token = tokenToUse,
                         workspaceId = workspaceInfo[workspaceId],
                         workspaceName = workspaceInfo[workspaceName],
@@ -168,7 +209,7 @@
                         sourceApplication = sourceApplication,
                         canHideBranding = workspaceInfo[canHideBranding],
                         versionId = versionId,
-                        url = url
+                        url = effectiveUrl
                     ],
 
                     // try to send to desktop service for backward compatibility (non-blocking)

--- a/src/powerbi-data-connector/speckle/GetByUrl.pqm
+++ b/src/powerbi-data-connector/speckle/GetByUrl.pqm
@@ -39,14 +39,8 @@
         // parse the URL to determine load shape
         parsedUrl = Parser(url),
 
-        // project-wide model load is expanded before token exchange and loading
-        projectWideModelIds = if parsedUrl[isProjectWideModelLoad] then
-            ProjectModels(parsedUrl[baseUrl], parsedUrl[projectId], ProjectWideModelLimit)
-        else
-            null,
-
         expandedResourceIdString = if parsedUrl[isProjectWideModelLoad] then
-            Text.Combine(projectWideModelIds, ",")
+            Text.Combine(ProjectModels(parsedUrl[baseUrl], parsedUrl[projectId], ProjectWideModelLimit), ",")
         else
             parsedUrl[resourceIdString],
 

--- a/src/powerbi-data-connector/speckle/GetByUrl.pqm
+++ b/src/powerbi-data-connector/speckle/GetByUrl.pqm
@@ -61,19 +61,7 @@
         else
             url,
 
-        effectiveParsedUrl = if parsedUrl[isProjectWideModelLoad] and expandedResourceIdString = "" then
-            [
-                baseUrl = parsedUrl[baseUrl],
-                projectId = parsedUrl[projectId],
-                modelId = "",
-                versionId = null,
-                isFederated = false,
-                isProjectWideModelLoad = false,
-                federatedModels = null,
-                resourceIdString = expandedResourceIdString
-            ]
-        else
-            Parser(effectiveUrl),
+        effectiveParsedUrl = Parser(effectiveUrl),
 
         metadataUrl = if parsedUrl[isProjectWideModelLoad] then url else effectiveUrl,
 

--- a/src/powerbi-data-connector/speckle/api/Parser.pqm
+++ b/src/powerbi-data-connector/speckle/api/Parser.pqm
@@ -14,6 +14,9 @@
         rawModelSegment = if List.Count(pathSegments) >= 4 and pathSegments{2} = "models"
             then pathSegments{3} else "",
             
+        // project-wide model load is a syntactic URL convention only
+        isProjectWideModelLoad = rawModelSegment = "all",
+
         // check if this is a federated model (contains commas)
         isFederated = Text.Contains(rawModelSegment, ","),
         
@@ -45,7 +48,7 @@
         if not isValid then
             error [
                 Reason = "Invalid URL",
-                Message = "The URL must be in the format 'https://server/projects/PROJECT_ID/models/MODEL_ID' or 'https://server/projects/PROJECT_ID/models/MODEL_ID@VERSION_ID' or 'https://server/projects/PROJECT_ID/models/MODEL_ID1,MODEL_ID2'"
+                Message = "The URL must be in the format 'https://server/projects/PROJECT_ID/models/MODEL_ID', 'https://server/projects/PROJECT_ID/models/MODEL_ID@VERSION_ID', 'https://server/projects/PROJECT_ID/models/MODEL_ID1,MODEL_ID2', or 'https://server/projects/PROJECT_ID/models/all'"
             ]
         else
             [
@@ -54,6 +57,7 @@
                 modelId = if isFederated then null else processedModels{0}[modelId],
                 versionId = if isFederated then null else processedModels{0}[versionId],
                 isFederated = isFederated,
+                isProjectWideModelLoad = isProjectWideModelLoad,
                 federatedModels = if isFederated then processedModels else null,
                 resourceIdString = rawModelSegment
             ]

--- a/src/powerbi-data-connector/speckle/api/Project.Models.pqm
+++ b/src/powerbi-data-connector/speckle/api/Project.Models.pqm
@@ -1,8 +1,6 @@
 // Function for resolving a project's flat model collection to model IDs
 (server as text, projectId as text, limit as number) as list =>
     let
-        ApiFetch = Extension.LoadFunction("Api.Fetch.pqm"),
-
         Extension.LoadFunction = (fileName as text) =>
             let
                 binary = Extension.Contents(fileName),
@@ -18,6 +16,8 @@
                             Message.Parameters = {fileName, e[Reason], e[Message]},
                             Detail = [File = fileName, Error = e]
                         ],
+
+        ApiFetch = Extension.LoadFunction("Api.Fetch.pqm"),
 
         query = "query ProjectModels($projectId: String!, $limit: Int!) {
             project(id: $projectId) {

--- a/src/powerbi-data-connector/speckle/api/Project.Models.pqm
+++ b/src/powerbi-data-connector/speckle/api/Project.Models.pqm
@@ -1,0 +1,41 @@
+// Function for resolving a project's flat model collection to model IDs
+(server as text, projectId as text, limit as number) as list =>
+    let
+        ApiFetch = Extension.LoadFunction("Api.Fetch.pqm"),
+
+        Extension.LoadFunction = (fileName as text) =>
+            let
+                binary = Extension.Contents(fileName),
+                asText = Text.FromBinary(binary)
+            in
+                try
+                    Expression.Evaluate(asText, #shared)
+                catch (e) =>
+                    error
+                        [
+                            Reason = "Extension.LoadFunction Failure",
+                            Message.Format = "Loading '#{0}' failed - '#{1}': '#{2}'",
+                            Message.Parameters = {fileName, e[Reason], e[Message]},
+                            Detail = [File = fileName, Error = e]
+                        ],
+
+        query = "query ProjectModels($projectId: String!, $limit: Int!) {
+            project(id: $projectId) {
+                models(limit: $limit) {
+                    items {
+                        id
+                    }
+                }
+            }
+        }",
+
+        variables = [
+            projectId = projectId,
+            limit = limit
+        ],
+
+        result = ApiFetch(server, query, variables),
+        items = result[project][models][items],
+        modelIds = List.Transform(items, each [id])
+    in
+        modelIds


### PR DESCRIPTION
## Summary

Adds support for loading all flat project models through the Power BI connector using the `/models/all` URL convention.

## What changed

* Added parsing support for project-wide model load URLs:
  * `https://app.speckle.systems/projects/PROJECT_ID/models/all`
* Added a `Project.Models.pqm` API helper that fetches the project model collection and returns model IDs.
* Updated `GetByUrl` so `/models/all` resolves to a federated model URL internally before loading data.
* Preserved permission checks, user lookup, and workspace lookup against the original `/models/all` URL while using the expanded model ID list for token exchange and model loading.
* Updated connector UI documentation to list federated model URLs and project-wide model load URLs.

https://github.com/user-attachments/assets/408c52d8-04fb-4b25-aa0b-6a4bbc25e232