### PR TITLE
Add instance property enrichment helper

### DIFF
--- a/src/powerbi-data-connector/Speckle.pq
+++ b/src/powerbi-data-connector/Speckle.pq
@@ -370,6 +370,20 @@ shared Speckle.ExpandProperties = Value.ReplaceType(
     ]
 );
 
+shared Speckle.AddInstanceProperties = Value.ReplaceType(
+    Speckle.LoadFunction("AddInstanceProperties.pqm"),
+    type function (
+        source as table,
+        propertyPaths as list
+    ) as table meta [
+        Documentation.Name = "Speckle - Add Instance Properties",
+        Documentation.DisplayName = "Speckle - Add Instance Properties",
+        Documentation.LongDescription =
+            "Returns the Objects table from Speckle.GetTables with the requested instance-property values appended. "
+            & "Pass exact dotted paths from the Property Paths table. Type properties are never used."
+    ]
+);
+
 // here we register the GetTables function to power bi ui — the single Get Data
 // entry; the legacy Speckle.GetByUrl stays unpublished but exported
 GetTables.Publish = [

--- a/src/powerbi-data-connector/speckle/artifact/AddInstanceProperties.pqm
+++ b/src/powerbi-data-connector/speckle/artifact/AddInstanceProperties.pqm
@@ -1,0 +1,129 @@
+// Adds selected instance EAV values to the Objects navigation table. This
+// deliberately has no dependency on Object Types or Type Properties: a value
+// that exists only at type grain must remain null here.
+(source as table, propertyPaths as list) as table =>
+    let
+        requiredKeys = {"objects", "properties", "paths"},
+        hasNavigationColumns = Table.HasColumns(source, {"Key", "Data"}),
+        availableKeys = if hasNavigationColumns then
+            List.Select(Table.Column(source, "Key"), each Value.Is(_, type text))
+        else
+            {},
+        missingKeys = if hasNavigationColumns then
+            List.Select(
+                requiredKeys,
+                each not List.Contains(availableKeys, _, Comparer.Ordinal)
+            )
+        else
+            requiredKeys,
+        validatedSource = if not hasNavigationColumns or not List.IsEmpty(missingKeys) then
+            error Error.Record(
+                "Speckle.AddInstanceProperties.InvalidNavigationSource",
+                "The source is missing required Speckle navigation entries: "
+                    & Text.Combine(missingKeys, ", ")
+                    & ". Expected: Speckle.AddInstanceProperties(Speckle.GetTables(url), propertyPaths).",
+                [MissingKeys = missingKeys, RequiredKeys = requiredKeys]
+            )
+        else
+            source,
+        objects = validatedSource{[Key = "objects"]}[Data],
+        properties = validatedSource{[Key = "properties"]}[Data],
+        paths = validatedSource{[Key = "paths"]}[Data],
+        invalidPathIndexes = List.Select(
+            List.Positions(propertyPaths),
+            (i) =>
+                let
+                    value = propertyPaths{i}
+                in
+                    if Value.Is(value, type text) then Text.Trim(value) = "" else true
+        ),
+        validatedPaths = if List.IsEmpty(invalidPathIndexes) then
+            propertyPaths
+        else
+            error Error.Record(
+                "Speckle.AddInstanceProperties.InvalidPropertyPaths",
+                "propertyPaths contains invalid items at positions "
+                    & Text.Combine(List.Transform(invalidPathIndexes, each Text.From(_ + 1)), ", ")
+                    & ". Each item must be non-empty text.",
+                [Positions = List.Transform(invalidPathIndexes, each _ + 1)]
+            ),
+        wanted = List.Distinct(
+            List.Transform(validatedPaths, each Text.Trim(_)),
+            Comparer.Ordinal
+        ),
+        existingNames = Table.ColumnNames(objects),
+        pathParts = List.Transform(wanted, each Text.Split(_, ".")),
+        Candidate = (parts as list, depth as number) as text =>
+            Text.Combine(List.LastN(parts, List.Min({depth, List.Count(parts)})), "."),
+        ResolveNames = (depths as list) as list =>
+            let
+                candidates = List.Transform(
+                    List.Positions(wanted),
+                    (i) => Candidate(pathParts{i}, depths{i})
+                ),
+                conflicts = List.Transform(
+                    List.Positions(candidates),
+                    (i) =>
+                        List.Contains(existingNames, candidates{i}, Comparer.Ordinal)
+                        or List.Count(
+                            List.PositionOf(candidates, candidates{i}, Occurrence.All, Comparer.Ordinal)
+                        ) > 1
+                ),
+                cannotGrow = List.Transform(
+                    List.Positions(conflicts),
+                    (i) => conflicts{i} and depths{i} >= List.Count(pathParts{i})
+                ),
+                nextDepths = List.Transform(
+                    List.Positions(depths),
+                    (i) => if conflicts{i} then depths{i} + 1 else depths{i}
+                )
+            in
+                if List.AnyTrue(cannotGrow) then
+                    error Error.Record(
+                        "Speckle.AddInstanceProperties.NameCollision",
+                        "Requested property columns cannot be made unique against the Objects columns.",
+                        [PropertyPaths = wanted, ExistingColumns = existingNames]
+                    )
+                else if List.AnyTrue(conflicts) then
+                    @ResolveNames(nextDepths)
+                else
+                    candidates,
+        outputNames = ResolveNames(List.Transform(wanted, each 1)),
+        // Paths is the small dimension. Filter it before the fact join so the
+        // Properties scan carries only requested path keys and the raw Value.
+        wantedPaths = Table.SelectColumns(
+            Table.SelectRows(
+                paths,
+                each List.Contains(wanted, [Property], Comparer.Ordinal)
+            ),
+            {"path_key", "Property"}
+        ),
+        selected = Table.ExpandTableColumn(
+            Table.NestedJoin(
+                Table.SelectColumns(properties, {"object_key", "path_key", "Value"}),
+                {"path_key"},
+                wantedPaths, {"path_key"},
+                "__path", JoinKind.Inner
+            ),
+            "__path", {"Property"}, {"__path"}
+        ),
+        grouped = Table.Group(
+            selected,
+            {"object_key"},
+            // (object_key, path_key) is a bundle invariant. Record.FromList is
+            // intentionally allowed to fail if malformed input violates it.
+            {{"__props", each Record.FromList([Value], [__path]), type record}}
+        ),
+        withProperties = Table.ExpandTableColumn(
+            Table.NestedJoin(
+                objects, {"object_key"},
+                grouped, {"object_key"},
+                "__group", JoinKind.LeftOuter
+            ),
+            "__group", {"__props"}, {"__props"}
+        )
+    in
+        if List.IsEmpty(wanted) then
+            objects
+        else
+            Table.ExpandRecordColumn(withProperties, "__props", wanted, outputNames)

--- a/src/powerbi-data-connector/tests/AddInstanceProperties.query.pq
+++ b/src/powerbi-data-connector/tests/AddInstanceProperties.query.pq
@@ -1,0 +1,247 @@
+let
+    Repr = (v as any) as text => try Text.FromBinary(Json.FromValue(v)) otherwise "<unserializable>",
+    Fact = (description as text, expected as any, actual as any) as record => [
+        Description = description,
+        Passed = (try expected = actual otherwise false) = true,
+        Expected = Repr(expected),
+        Actual = Repr(try actual otherwise "<error>")
+    ],
+    Summarize = (facts as list) as text =>
+        let
+            failures = List.Select(facts, each not [Passed])
+        in
+            if List.IsEmpty(failures) then
+                "PASSED " & Text.From(List.Count(facts)) & " facts"
+            else
+                error Text.Combine(
+                    List.Transform(
+                        failures,
+                        each "FAILED: " & [Description] & " (expected " & [Expected] & ", got " & [Actual] & ")"
+                    ),
+                    "#(lf)"
+                ),
+
+    Objects = #table(
+        type table [object_key = Int64.Type, #"Application ID" = text],
+        {{1, "one"}, {2, "two"}, {3, "three"}}
+    ) meta [TestMarker = "original Objects"],
+    Properties = #table(
+        type table [
+            object_key = Int64.Type,
+            path_key = Int64.Type,
+            #"Value Text" = nullable text,
+            #"Value Number" = nullable number,
+            #"Value Bool" = nullable logical,
+            Value = any
+        ],
+        {
+            {1, 10, "typed-column-must-not-win", null, null, 42.5},
+            {2, 10, null, 999, null, "instance-value"},
+            {1, 11, null, 11, null, 11},
+            {1, 12, null, 12, null, 12},
+            {1, 13, "identity-name", null, null, "identity-name"}
+        }
+    ),
+    Paths = #table(
+        type table [path_key = Int64.Type, Property = text],
+        {
+            {10, "properties.Dimensions.Area"},
+            {11, "properties.Quantities.Area"},
+            {12, "properties.Geometry.Dimensions.Area"},
+            {13, "properties.Identity.Application ID"}
+        }
+    ),
+    ObjectTypes = #table(
+        type table [object_key = Int64.Type, type_key = Int64.Type],
+        {{3, 100}}
+    ),
+    TypeProperties = #table(
+        type table [type_key = Int64.Type, path_key = Int64.Type, Value = any],
+        {{100, 10, "type-only-value-must-not-appear"}}
+    ),
+    Source = #table(
+        type table [Name = text, Key = text, Data = table, ItemKind = text, ItemName = text, IsLeaf = logical],
+        {
+            {"Objects", "objects", Objects, "Table", "Table", true},
+            {"Properties", "properties", Properties, "Table", "Table", true},
+            {"Property Paths", "paths", Paths, "Table", "Table", true},
+            {"Object Types", "object-types", ObjectTypes, "Table", "Table", true},
+            {"Type Properties", "type-properties", TypeProperties, "Table", "Table", true}
+        }
+    ),
+    Result = Speckle.AddInstanceProperties(Source, {"properties.Dimensions.Area"}),
+    EmptyResult = Speckle.AddInstanceProperties(Source, {}),
+    NormalizedResult = Speckle.AddInstanceProperties(
+        Source,
+        {" properties.Dimensions.Area ", "properties.Dimensions.Area"}
+    ),
+    NamingResult = Speckle.AddInstanceProperties(
+        Source,
+        {
+            "properties.Geometry.Dimensions.Area",
+            "properties.Quantities.Area",
+            "properties.Dimensions.Area",
+            "properties.Identity.Application ID"
+        }
+    ),
+    InvalidPathResult = try Speckle.AddInstanceProperties(
+        Source,
+        {null, "   ", 123, "properties.Dimensions.Area"}
+    ),
+    InvalidPathError = if not InvalidPathResult[HasError] then
+        [Reason = null, Positions = {}]
+    else
+        [
+            Reason = try InvalidPathResult[Error][Reason] otherwise null,
+            Positions = try InvalidPathResult[Error][Detail][Positions] otherwise {}
+        ],
+    MissingNavigationResult = try Speckle.AddInstanceProperties(
+        Table.SelectRows(Source, each [Key] = "objects"),
+        {"properties.Dimensions.Area"}
+    ),
+    MissingNavigationError = if not MissingNavigationResult[HasError] then
+        [Reason = null, MissingKeys = {}, ShowsCallShape = false]
+    else
+        [
+            Reason = try MissingNavigationResult[Error][Reason] otherwise null,
+            MissingKeys = try MissingNavigationResult[Error][Detail][MissingKeys] otherwise {},
+            ShowsCallShape = try Text.Contains(
+                MissingNavigationResult[Error][Message],
+                "Speckle.AddInstanceProperties(Speckle.GetTables(url), propertyPaths)"
+            ) otherwise false
+        ],
+    UnknownAndCaseResult = Speckle.AddInstanceProperties(
+        Source,
+        {"PROPERTIES.Dimensions.Area", "properties.Unknown.Value"}
+    ),
+    FederatedObjects = #table(
+        type table [object_key = Int64.Type, #"Application ID" = text],
+        {{1, "model-a"}, {4294967297, "model-b"}}
+    ),
+    FederatedProperties = #table(
+        type table [object_key = Int64.Type, path_key = Int64.Type, Value = any],
+        {{1, 10, "first-model"}, {4294967297, 4294967306, "second-model"}}
+    ),
+    FederatedPaths = #table(
+        type table [path_key = Int64.Type, Property = text],
+        {
+            {10, "properties.Identity.Name"},
+            {4294967306, "properties.Identity.Name"}
+        }
+    ),
+    FederatedSource = #table(
+        type table [Name = text, Key = text, Data = table, ItemKind = text, ItemName = text, IsLeaf = logical],
+        {
+            {"Objects", "objects", FederatedObjects, "Table", "Table", true},
+            {"Properties", "properties", FederatedProperties, "Table", "Table", true},
+            {"Property Paths", "paths", FederatedPaths, "Table", "Table", true}
+        }
+    ),
+    FederatedResult = Speckle.AddInstanceProperties(
+        FederatedSource,
+        {"properties.Identity.Name"}
+    ),
+    UnreadTypeEntriesSource = #table(
+        type table [Name = text, Key = text, Data = any, ItemKind = text, ItemName = text, IsLeaf = logical],
+        {
+            {"Objects", "objects", Objects, "Table", "Table", true},
+            {"Properties", "properties", Properties, "Table", "Table", true},
+            {"Property Paths", "paths", Paths, "Table", "Table", true},
+            {"Object Types", "object-types", error "Object Types must not be read", "Table", "Table", true},
+            {"Type Properties", "type-properties", error "Type Properties must not be read", "Table", "Table", true}
+        }
+    ),
+    UnreadTypeEntriesResult = Speckle.AddInstanceProperties(
+        UnreadTypeEntriesSource,
+        {"properties.Dimensions.Area"}
+    ),
+
+    facts = {
+        Fact(
+            "requested instance values are appended without losing objects",
+            {{1, "one", 42.5}, {2, "two", "instance-value"}, {3, "three", null}},
+            Table.ToRows(Result)
+        ),
+        Fact(
+            "type-only values stay null and Properties Value is used directly",
+            {42.5, "instance-value", null},
+            Table.Column(Result, "Area")
+        ),
+        Fact(
+            "Object Types and Type Properties navigation data are never read",
+            {42.5, "instance-value", null},
+            Table.Column(UnreadTypeEntriesResult, "Area")
+        ),
+        Fact(
+            "added property columns have type any",
+            true,
+            Type.Is(type any, Type.TableColumn(Value.Type(Result), "Area"))
+        ),
+        Fact(
+            "an empty path list returns the original Objects table unchanged",
+            [
+                Columns = {"object_key", "Application ID"},
+                Rows = {{1, "one"}, {2, "two"}, {3, "three"}},
+                Marker = "original Objects"
+            ],
+            [
+                Columns = Table.ColumnNames(EmptyResult),
+                Rows = Table.ToRows(EmptyResult),
+                Marker = try Value.Metadata(EmptyResult)[TestMarker] otherwise null
+            ]
+        ),
+        Fact(
+            "paths are trimmed and deduplicated before naming",
+            {"object_key", "Application ID", "Area"},
+            Table.ColumnNames(NormalizedResult)
+        ),
+        Fact(
+            "shortest unique suffixes include parents in natural order",
+            {
+                "object_key",
+                "Application ID",
+                "Geometry.Dimensions.Area",
+                "Quantities.Area",
+                "properties.Dimensions.Area",
+                "Identity.Application ID"
+            },
+            Table.ColumnNames(NamingResult)
+        ),
+        Fact(
+            "invalid path items report all one-based positions",
+            [
+                Reason = "Speckle.AddInstanceProperties.InvalidPropertyPaths",
+                Positions = {1, 2, 3}
+            ],
+            InvalidPathError
+        ),
+        Fact(
+            "missing navigation entries fail together before joins",
+            [
+                Reason = "Speckle.AddInstanceProperties.InvalidNavigationSource",
+                MissingKeys = {"properties", "paths"},
+                ShowsCallShape = true
+            ],
+            MissingNavigationError
+        ),
+        Fact(
+            "unknown and differently-cased paths produce null columns",
+            [
+                Columns = {"object_key", "Application ID", "Area", "Value"},
+                Values = {{null, null}, {null, null}, {null, null}}
+            ],
+            [
+                Columns = Table.ColumnNames(UnknownAndCaseResult),
+                Values = Table.ToRows(
+                    Table.SelectColumns(UnknownAndCaseResult, {"Area", "Value"})
+                )
+            ]
+        ),
+        Fact(
+            "federated duplicate path names resolve by namespaced path key",
+            {{1, "model-a", "first-model"}, {4294967297, "model-b", "second-model"}},
+            Table.ToRows(FederatedResult)
+        )
+    }
+in
+    Summarize(facts)

--- a/src/powerbi-data-connector/tests/Exports.Contract.query.pq
+++ b/src/powerbi-data-connector/tests/Exports.Contract.query.pq
@@ -40,6 +40,9 @@ let
         Fact("GetTables returns table", true, ReturnsTable(Speckle.GetTables)),
         Fact("ExpandProperties parameters", {"url", "propertyPaths"}, ParamNames(Speckle.ExpandProperties)),
         Fact("ExpandProperties required arity", 1, RequiredCount(Speckle.ExpandProperties)),
+        Fact("AddInstanceProperties parameters", {"source", "propertyPaths"}, ParamNames(Speckle.AddInstanceProperties)),
+        Fact("AddInstanceProperties required arity", 2, RequiredCount(Speckle.AddInstanceProperties)),
+        Fact("AddInstanceProperties returns table", true, ReturnsTable(Speckle.AddInstanceProperties)),
 
         // 3.x single-parameter interfaces preserved
         Fact("GetStructuredData parameters", {"url"}, ParamNames(Speckle.GetStructuredData)),

--- a/src/powerbi-data-connector/tests/README.md
+++ b/src/powerbi-data-connector/tests/README.md
@@ -19,6 +19,9 @@ listing the failed facts.
 - `Legacy.Shapes.query.pq` — the restored legacy data-shaping helpers against
   legacy-shaped inputs (the flat shapes returned by `Speckle.GetByUrl`).
   These helpers are not expected to accept `Speckle.GetTables` output.
+- `AddInstanceProperties.query.pq` — the shared instance-property enrichment
+  helper against in-memory star-schema navigation tables, including validation,
+  null, naming, typing, and federated-key behavior.
 
 ## Live suite (manual, needs a server + credential)
 


### PR DESCRIPTION
## Summary

- export the documented `Speckle.AddInstanceProperties(source, propertyPaths)` helper
- enrich the `Objects` navigation table from instance `Properties[Value]` rows only
- validate navigation keys and path inputs, preserving object rows and request order
- resolve output names with shortest unique dotted-path suffixes
- add offline coverage for nulls, typing, naming collisions, federation, validation, and type-property exclusion

## Why

This gives Power Query users a shared helper for appending selected instance properties to the `Objects` table returned by `Speckle.GetTables`, without resolving or falling back to type properties.

## Impact

Existing `Speckle.GetTables` and `Speckle.ExpandProperties` behavior remains unchanged. The new helper is intentionally unpublished from Get Data and requires the complete path list in one call.

## Validation

- `MSBuild.exe Speckle.proj /t:BuildMez /p:IsContinuousIntegrationBuild=true`
- full offline PQTest suite: 53 facts passed
  - `AddInstanceProperties.query.pq`: 11
  - `Exports.Contract.query.pq`: 24
  - `Legacy.Shapes.query.pq`: 18
