### PR TITLE
feat(visual): move the 3D viewer to viewer packages 2026.9.0

### DIFF
--- a/src/powerbi-visual/package-lock.json
+++ b/src/powerbi-visual/package-lock.json
@@ -10,8 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "@heroicons/vue": "^2.0.12",
-        "@speckle/viewer-tools": "2026.8.21",
-        "@speckle/viewer-webgpu": "2026.8.21",
+        "@speckle/viewer-tools": "2026.9.0",
+        "@speckle/viewer-webgpu": "2026.9.0",
         "@vueuse/core": "^13.2.0",
         "hyparquet": "^1.16.0",
         "hyparquet-compressors": "^1.1.1",
@@ -466,21 +466,21 @@
       }
     },
     "node_modules/@speckle/viewer-tools": {
-      "version": "2026.8.21",
-      "resolved": "https://npmregistry.mermaid-emperor.ts.net/@speckle/viewer-tools/-/viewer-tools-2026.8.21.tgz",
-      "integrity": "sha512-aNz/RqYJJyMko+w5Ou+1J9IRXjhtxBG/dq8w7TznQ8gWM/v1s9VRJi8GKI09LpyFDWcS+r0rem2tslBdqgVTKQ==",
+      "version": "2026.9.0",
+      "resolved": "https://npmregistry.mermaid-emperor.ts.net/@speckle/viewer-tools/-/viewer-tools-2026.9.0.tgz",
+      "integrity": "sha512-sxgnW1VTw3LivsgNE3va6+NHT/QmTObl5ON6JUIyBGDwJZVV9keIqFD5Rny0xuQV9Ip5Jww/EBxUBXkZO5XUgA==",
       "dependencies": {
         "perfect-freehand": "^1.2.3",
         "threejs-math": "0.147.0"
       },
       "peerDependencies": {
-        "@speckle/viewer-webgpu": "2026.8.21"
+        "@speckle/viewer-webgpu": "2026.9.0"
       }
     },
     "node_modules/@speckle/viewer-webgpu": {
-      "version": "2026.8.21",
-      "resolved": "https://npmregistry.mermaid-emperor.ts.net/@speckle/viewer-webgpu/-/viewer-webgpu-2026.8.21.tgz",
-      "integrity": "sha512-79HTmqS/Y6GzXRE86F6Y3om8gXmroArCdC4OAiue7RMe7hwrbYbSaSg4/RkvFGjB23weYym3UBPzcP0x6RzSYQ==",
+      "version": "2026.9.0",
+      "resolved": "https://npmregistry.mermaid-emperor.ts.net/@speckle/viewer-webgpu/-/viewer-webgpu-2026.9.0.tgz",
+      "integrity": "sha512-XWBJZ8yFx0IbAmz17VMlUifB076GXHM+Rm92K430dfqfkMXlJGisafNDf0eOuDgveWIGL1CU3Xyk2ylXQET4zg==",
       "dependencies": {
         "threejs-math": "0.147.0"
       },

--- a/src/powerbi-visual/package.json
+++ b/src/powerbi-visual/package.json
@@ -11,12 +11,12 @@
     "build": "webpack --config webpack.config.ts",
     "build:dev": "webpack --config webpack.config.dev.ts",
     "dev": "webpack-dev-server --config webpack.config.dev.ts",
-    "test": "ts-node --project test/tsconfig.json test/matrixSignature.test.ts && ts-node --project test/tsconfig.json test/colorOverrides.test.ts && ts-node --project test/tsconfig.json test/objectIdentity.test.ts && ts-node --project test/tsconfig.json -r tsconfig-paths/register test/viewerInitialization.test.ts && ts-node --project test/tsconfig.json -r tsconfig-paths/register test/idModeLifecycle.test.ts && ts-node --project test/tsconfig.viewer3.json test/modelReadyColorReplay.test.ts"
+    "test": "ts-node --project test/tsconfig.json test/matrixSignature.test.ts && ts-node --project test/tsconfig.json test/colorOverrides.test.ts && ts-node --project test/tsconfig.json test/objectIdentity.test.ts && ts-node --project test/tsconfig.json -r tsconfig-paths/register test/viewerInitialization.test.ts && ts-node --project test/tsconfig.json -r tsconfig-paths/register test/idModeLifecycle.test.ts && ts-node --project test/tsconfig.viewer3.json test/modelReadyColorReplay.test.ts && ts-node --project test/tsconfig.viewer3.json test/modelMaps.test.ts && ts-node --project test/tsconfig.viewer3.json test/pickSelection.test.ts && ts-node --project test/tsconfig.viewer3.json test/doubleClick.test.ts"
   },
   "dependencies": {
     "@heroicons/vue": "^2.0.12",
-    "@speckle/viewer-tools": "2026.8.21",
-    "@speckle/viewer-webgpu": "2026.8.21",
+    "@speckle/viewer-tools": "2026.9.0",
+    "@speckle/viewer-webgpu": "2026.9.0",
     "@vueuse/core": "^13.2.0",
     "hyparquet": "^1.16.0",
     "hyparquet-compressors": "^1.1.1",

--- a/src/powerbi-visual/src/plugins/viewer.ts
+++ b/src/powerbi-visual/src/plugins/viewer.ts
@@ -19,6 +19,10 @@
  */
 import type { Renderer } from '@speckle/viewer-webgpu'
 import { createRendererBridge, type RendererBridge } from '@src/viewer3/bridge'
+import {
+  resolveDoubleClickTarget,
+  type PlacementHit
+} from '@src/viewer3/doubleClick'
 import { createViewerInteractions } from '@src/viewer3/objects/index'
 import type { ObjectGroup, ObjectRef, ViewerInteractions } from '@src/viewer3/objects/types'
 import {
@@ -220,8 +224,17 @@ export class ViewerHandler {
       renderer.setProjection('orthographic')
     }
 
-    // Double-click on empty space = zoom extents (the renderer zooms to object on hits).
-    renderer.onDoubleClickMiss = () => this.zoomExtends()
+    // Double-click framing. Up to viewer-webgpu 2026.8.21 the renderer did the
+    // hit case itself (fitToSphere on the picked primitive); 2026.8.31 reduced
+    // it to emitting the hits, so the host owns the whole gesture now. Its
+    // `onDoubleClickMiss` hook is NOT the miss half — that property has never
+    // been invoked by any shipped renderer; the miss arrives here as an empty
+    // hit list.
+    this.unsubscribers.push(
+      this.bridge.emitter.on('viewer:doubleClickIntersectResult', (payload) =>
+        this.handleDoubleClick(payload as { hits: PlacementHit[] })
+      )
+    )
 
     // Streaming ticker (~1/s while frames render): pre-paint it enriches the blocking
     // overlay with MB/s; post-paint it drives the small pill (5s decay, like frontend-3).
@@ -262,7 +275,7 @@ export class ViewerHandler {
     // selection to this same pick event; we only translate it for the host.
     canvas.addEventListener('pointerup', this.capturePointerUp, { capture: true })
     this.unsubscribers.push(
-      this.bridge.emitter.on('viewer:placementsPicked', (payload) =>
+      this.bridge.emitter.on('viewer:placementPicked', (payload) =>
         this.handlePlacementsPicked(
           payload as {
             modelId: string
@@ -402,12 +415,12 @@ export class ViewerHandler {
 
   public zoomObjects = (objectIds: string[]) => {
     if (!this.renderer) return
-    zoomToObjects(this.renderer, this.toGroups(objectIds))
+    zoomToObjects(this.renderer, this.bridge.getModelMaps, this.toGroups(objectIds))
   }
 
   public zoomExtends = () => {
     if (!this.renderer) return
-    zoomToObjects(this.renderer)
+    zoomToObjects(this.renderer, this.bridge.getModelMaps)
   }
 
   /** The renderer re-measures only on window resize, which the PBI sandbox doesn't
@@ -712,7 +725,7 @@ export class ViewerHandler {
         continue
       }
       // The renderer registers the model under `bundle_${versionId}` (its internal
-      // artifact id — the id picks report and getModelMaps expects). Key EVERYTHING
+      // artifact id — the id picks report and the maps cache is keyed by). Key EVERYTHING
       // by that id or every paint/pick silently no-ops.
       const rendererModelId = `bundle_${model.versionId}`
       this.loadedModelIds.push(rendererModelId)
@@ -747,7 +760,7 @@ export class ViewerHandler {
     // no dictionary required); dictionary sizes are the fallback.
     let totalObjects = 0
     for (const rendererModelId of this.loadedModelIds) {
-      const maps = renderer.getModelMaps(rendererModelId)
+      const maps = this.bridge.getModelMaps(rendererModelId)
       if (maps) totalObjects += maps.objectCsr.objectCount
       else totalObjects += this.dictionaries.get(rendererModelId)?.toIndex.size ?? 0
     }
@@ -799,6 +812,29 @@ export class ViewerHandler {
     this.lastPointerUp = ev
   }
 
+  /**
+   * Double-click → frame what's under the cursor; empty space → zoom extents.
+   * Restores the behavior viewer-webgpu dropped in 2026.8.31; the resolution
+   * itself lives in {@link resolveDoubleClickTarget}.
+   */
+  private handleDoubleClick = (payload: { hits: PlacementHit[] }) => {
+    const renderer = this.renderer
+    if (!renderer) return
+    const target = resolveDoubleClickTarget({
+      hits: payload?.hits,
+      firstVisibleHit: (hits) =>
+        renderer.getFirstVisibleHit(
+          hits as Parameters<typeof renderer.getFirstVisibleHit>[0]
+        ),
+      modelAt: (placementIndex) => renderer.scene.modelAt(placementIndex),
+      getModelMaps: this.bridge.getModelMaps
+    })
+    if (target.kind === 'extents') this.zoomExtends()
+    else if (target.kind === 'object') {
+      zoomToObjects(renderer, this.bridge.getModelMaps, [target.group])
+    }
+  }
+
   /** The renderer's pick result → the host's Hit (guid = applicationId). */
   private handlePlacementsPicked = (payload: {
     modelId: string
@@ -813,8 +849,8 @@ export class ViewerHandler {
     let hit: Hit | null = null
     const pick = payload.pickResult
     if (pick && this.renderer) {
-      const maps = this.renderer.getModelMaps(payload.modelId)
-      const objectIndex = maps?.placementObjectIdx[pick.placementIndex]
+      const maps = this.bridge.getModelMaps(payload.modelId)
+      const objectIndex = maps?.objectOfPlacement(pick.placementIndex)
       const appId =
         objectIndex !== undefined
           ? this.boundIdOf({ modelId: payload.modelId, objectIndex })

--- a/src/powerbi-visual/src/viewer3/boot.ts
+++ b/src/powerbi-visual/src/viewer3/boot.ts
@@ -9,7 +9,7 @@ import { createRenderer } from '@speckle/viewer-webgpu'
 import { installCameraControls } from '@speckle/viewer-tools'
 import type { Emitter, Renderer } from '@speckle/viewer-webgpu'
 import type { BridgeEmitter } from './bridge.js'
-import type { ObjectGroup } from './objects/types.js'
+import type { ObjectGroup, ViewerModelMaps } from './objects/types.js'
 
 /** Vendored from @speckle/ts-sdk viewer-state/state.ts (the one type this module needs). */
 export interface ViewerCameraState {
@@ -154,12 +154,20 @@ export const setCanonicalView = (renderer: Renderer, view: CanonicalView): void 
 
 /**
  * Fly the camera to frame the given object groups (the whole scene when none
- * given). Objects expand to placements via the renderer's own CSR maps, then
- * their merged bounds feed `controls.fitToSphere` — the supported programmatic
- * camera drive. Groups whose model isn't loaded (or whose objects have no
- * geometry) contribute nothing; if nothing contributes, the camera stays put.
+ * given). Objects expand to placements via the CSR maps, then their merged
+ * bounds feed `controls.fitToSphere` — the supported programmatic camera
+ * drive. Groups whose model isn't loaded (or whose objects have no geometry)
+ * contribute nothing; if nothing contributes, the camera stays put.
+ *
+ * `getModelMaps` is passed in (the bridge's) rather than read off the
+ * renderer: viewer-webgpu dropped its own accessor in 2026.8.31 and the host
+ * now owns the maps.
  */
-export const zoomToObjects = (renderer: Renderer, groups?: ObjectGroup[]): void => {
+export const zoomToObjects = (
+  renderer: Renderer,
+  getModelMaps: (modelId: string) => ViewerModelMaps | null,
+  groups?: ObjectGroup[]
+): void => {
   const controls = renderer.getCameraRig()
   if (!groups || groups.length === 0) {
     controls.fitToSphere(renderer.scene.getBoundingSphere())
@@ -167,7 +175,7 @@ export const zoomToObjects = (renderer: Renderer, groups?: ObjectGroup[]): void 
   }
   let bounds: Box3Like | null = null
   for (const group of groups) {
-    const maps = renderer.getModelMaps(group.modelId)
+    const maps = getModelMaps(group.modelId)
     if (!maps) continue
     const { offsets, placements: csrPlacements } = maps.objectCsr
     const placements: number[] = []

--- a/src/powerbi-visual/src/viewer3/bridge.ts
+++ b/src/powerbi-visual/src/viewer3/bridge.ts
@@ -1,5 +1,6 @@
 // Vendored from @speckle/ts-sdk (packages/ts-sdk/src/viewer/bridge.ts, speckle-server-internal@speckle/next).
 // @speckle/ts-sdk is private/unpublished; keep this copy in sync until it ships.
+import { createModelMapsCache, type SemanticMaps } from './modelMaps.js'
 import type { ViewerHandle } from './objects/types.js'
 import type { Renderer } from '@speckle/viewer-webgpu'
 
@@ -48,6 +49,12 @@ export interface RendererBridge {
   handle: ViewerHandle
   bind: (renderer: Renderer) => void
   unbind: () => void
+  /**
+   * The maps the bridge maintains off the load/unload events — for the few
+   * call sites that hold the raw `Renderer` (camera framing, object counts)
+   * and used to call `Renderer.getModelMaps` themselves.
+   */
+  getModelMaps: ViewerHandle['getModelMaps']
 }
 
 /**
@@ -62,9 +69,28 @@ export interface RendererBridge {
 export const createRendererBridge = (): RendererBridge => {
   const emitter = new BridgeEmitter()
   let live: Renderer | null = null
+
+  // The maps arrive ONCE, in the load event (viewer-webgpu >= 2026.8.31 has no
+  // getModelMaps accessor), so the cache must be listening before the renderer
+  // exists — which is exactly what the bridge-owned bus is for. Subscribing
+  // here also puts the cache ahead of the interactions layer in listener
+  // order, so its `model-ready` repaint always finds the model paintable.
+  const modelMaps = createModelMapsCache()
+  emitter.on('viewer:loadArtifactComplete', (payload) => {
+    const { artifactId, semanticMaps } = payload as {
+      artifactId: string
+      semanticMaps: SemanticMaps
+    }
+    if (semanticMaps) modelMaps.register(artifactId, semanticMaps)
+  })
+  emitter.on('viewer:unloadArtifactComplete', (payload) => {
+    const { artifactId } = payload as { artifactId: string | null }
+    modelMaps.unregister(artifactId)
+  })
+
   const handle: ViewerHandle = {
     on: (event, handler) => emitter.on(event, handler),
-    getModelMaps: (modelId) => live?.getModelMaps(modelId) ?? null,
+    getModelMaps: (modelId) => modelMaps.get(modelId),
     setColor: (placements, rgba) => live?.setColor(placements, rgba),
     resetMaterials: (placements) => live?.resetMaterialBatched(placements),
     hideObjects: (indices) => live?.hideObjects(indices),
@@ -74,11 +100,14 @@ export const createRendererBridge = (): RendererBridge => {
   return {
     emitter,
     handle,
+    getModelMaps: (modelId) => modelMaps.get(modelId),
     bind: (renderer): void => {
       live = renderer
+      modelMaps.bind(renderer)
     },
     unbind: (): void => {
       live = null
+      modelMaps.clear()
     }
   }
 }

--- a/src/powerbi-visual/src/viewer3/doubleClick.ts
+++ b/src/powerbi-visual/src/viewer3/doubleClick.ts
@@ -1,0 +1,50 @@
+/**
+ * What a double-click should frame.
+ *
+ * viewer-webgpu did this itself up to 2026.8.21 (`fitToSphere` on the picked
+ * primitive); 2026.8.31 reduced the renderer's role to emitting the hit list,
+ * so the host owns the gesture. The resolution is pure and takes its renderer
+ * reads as functions, which keeps it testable without a GPU — the same shape
+ * `zoomToObjects` uses.
+ */
+import type { ObjectGroup, ViewerModelMaps } from './objects/types.js'
+
+/** The only field of the renderer's RayPickResult this resolution needs. */
+export interface PlacementHit {
+  placementIndex: number
+}
+
+export type DoubleClickTarget =
+  /** Empty space — frame the whole scene. */
+  | { kind: 'extents' }
+  /** Frame this object (all of its placements, not just the primitive hit). */
+  | { kind: 'object'; group: ObjectGroup }
+  /** Hits exist but resolve to nothing framable — leave the camera alone. */
+  | { kind: 'none' }
+
+export const resolveDoubleClickTarget = (input: {
+  hits: readonly PlacementHit[] | null | undefined
+  /**
+   * The renderer's own visibility-aware hit filter. Using it (rather than
+   * `hits[0]`, which is what the old renderer did) stops a double-click from
+   * flying to geometry the user has hidden, isolated away or filtered out.
+   */
+  firstVisibleHit: (hits: readonly PlacementHit[]) => PlacementHit | null
+  /** Which loaded model owns a global placement index. */
+  modelAt: (placementIndex: number) => string | null
+  getModelMaps: (modelId: string) => ViewerModelMaps | null
+}): DoubleClickTarget => {
+  const { hits, firstVisibleHit, modelAt, getModelMaps } = input
+  if (!hits || hits.length === 0) return { kind: 'extents' }
+
+  const hit = firstVisibleHit(hits)
+  if (!hit) return { kind: 'none' }
+
+  const modelId = modelAt(hit.placementIndex)
+  if (!modelId) return { kind: 'none' }
+
+  const objectIndex = getModelMaps(modelId)?.objectOfPlacement(hit.placementIndex)
+  if (objectIndex === undefined) return { kind: 'none' }
+
+  return { kind: 'object', group: { modelId, objectIndexes: [objectIndex] } }
+}

--- a/src/powerbi-visual/src/viewer3/modelMaps.ts
+++ b/src/powerbi-visual/src/viewer3/modelMaps.ts
@@ -1,0 +1,179 @@
+// Vendored-adjacent to @speckle/ts-sdk (packages/ts-sdk/src/viewer/…, speckle-server-internal@speckle/next).
+// @speckle/ts-sdk is private/unpublished; upstream needs this same shim for viewer-webgpu >= 2026.8.31.
+/**
+ * The placement↔object maps, rebuilt host-side.
+ *
+ * Up to viewer-webgpu 2026.8.28 the renderer handed these out directly
+ * (`Renderer.getModelMaps`): a per-model reverse CSR of GLOBAL placement ids
+ * plus a global forward map. 2026.8.31 removed that accessor and replaced the
+ * data with model-local REALIZATION semantics, delivered exactly once — in the
+ * `viewer:loadArtifactComplete` payload. Holding the maps is now the host's
+ * job, so this cache is where the old contract is reconstituted.
+ *
+ * Two facts drive the implementation:
+ *
+ *  - `placementRealizationIdx` is model-local (index p = the model's p-th
+ *    placement, meshes then lines). The global placement id the renderer's
+ *    paint API speaks is `placementRange[0] + p`.
+ *  - That base MOVES: unloading an earlier model compacts the placement SoA
+ *    and shifts every survivor's range down. The old viewer rebased its own
+ *    CSR in place on `removeModel`; nothing does that for us now, so `get()`
+ *    re-reads the live range and rebases when it has drifted.
+ *
+ * The derived arrays are built once per load (a counting sort, the same shape
+ * the viewer used to build internally) and then only ever shifted, so paint
+ * loops calling `get()` per model stay allocation-free.
+ */
+import type { Renderer } from '@speckle/viewer-webgpu'
+import type { ViewerModelMaps } from './objects/types.js'
+
+/** The `viewer:loadArtifactComplete` semantics payload (viewer-webgpu >= 2026.8.31). */
+export interface SemanticMaps {
+  /** Model-local placement index → realization id. Length = the model's placement count. */
+  placementRealizationIdx: Uint32Array
+  /** Realization id → dense object index. Instances share an object. */
+  realizationObjectIdx: Uint32Array
+  objectCount: number
+}
+
+interface Entry {
+  /** Object index → slice bounds into `placements`. Length objectCount + 1. */
+  offsets: Uint32Array
+  /** Placement ids grouped by object — GLOBAL, valid for `base`. */
+  placements: Uint32Array
+  /** The placement-range start `placements` is currently expressed against. */
+  base: number
+  semantics: SemanticMaps
+  /** Handed to consumers as-is; `placements` is mutated in place under it. */
+  view: ViewerModelMaps
+}
+
+export interface ModelMapsCache {
+  /** Ingest a load event. */
+  register(modelId: string, semantics: SemanticMaps): void
+  /** Drop one model, or the whole scene when null. */
+  unregister(modelId: string | null): void
+  /** The renderer to read live placement ranges from; null unbinds. */
+  bind(renderer: Renderer | null): void
+  /** Null when the model never loaded, already unloaded, or has no live range. */
+  get(modelId: string): ViewerModelMaps | null
+  clear(): void
+}
+
+/**
+ * Counting-sort the model-local placements by owning object, then bias into
+ * global ids. Placements whose realization resolves outside `objectCount` are
+ * dropped rather than trusted — a corrupt lane must not smear paint onto a
+ * neighbouring object.
+ */
+const buildCsr = (
+  semantics: SemanticMaps,
+  base: number
+): { offsets: Uint32Array; placements: Uint32Array } => {
+  const { placementRealizationIdx, realizationObjectIdx, objectCount } = semantics
+  const placementCount = placementRealizationIdx.length
+  const offsets = new Uint32Array(objectCount + 1)
+
+  /** The object a model-local placement paints, or -1 when unresolvable. */
+  const objectOf = (localPlacement: number): number => {
+    const realization = placementRealizationIdx[localPlacement]
+    if (realization === undefined || realization >= realizationObjectIdx.length) return -1
+    const objectIndex = realizationObjectIdx[realization]
+    if (objectIndex === undefined || objectIndex >= objectCount) return -1
+    return objectIndex
+  }
+
+  for (let p = 0; p < placementCount; p++) {
+    const objectIndex = objectOf(p)
+    if (objectIndex >= 0) offsets[objectIndex + 1]++
+  }
+  for (let o = 0; o < objectCount; o++) offsets[o + 1] += offsets[o]
+
+  const placements = new Uint32Array(offsets[objectCount])
+  const cursor = offsets.slice(0, objectCount)
+  for (let p = 0; p < placementCount; p++) {
+    const objectIndex = objectOf(p)
+    if (objectIndex >= 0) placements[cursor[objectIndex]++] = base + p
+  }
+  return { offsets, placements }
+}
+
+export const createModelMapsCache = (): ModelMapsCache => {
+  const entries = new Map<string, Entry>()
+  let live: Renderer | null = null
+
+  /** The model's current global placement base, or null when it has no range. */
+  const baseOf = (modelId: string): number | null => {
+    const range = live?.getModelPlacementRange(modelId)
+    return range ? range[0] : null
+  }
+
+  const makeEntry = (modelId: string, semantics: SemanticMaps): Entry => {
+    const base = baseOf(modelId) ?? 0
+    const { offsets, placements } = buildCsr(semantics, base)
+    const entry: Entry = {
+      offsets,
+      placements,
+      base,
+      semantics,
+      // Placeholder; replaced below so the view can close over `entry`.
+      view: null as unknown as ViewerModelMaps
+    }
+    entry.view = {
+      objectCsr: {
+        offsets,
+        placements,
+        objectCount: semantics.objectCount
+      },
+      objectOfPlacement: (placementIndex: number): number | undefined => {
+        const local = placementIndex - entry.base
+        if (local < 0 || local >= entry.semantics.placementRealizationIdx.length) {
+          return undefined
+        }
+        const realization = entry.semantics.placementRealizationIdx[local]
+        if (realization === undefined) return undefined
+        const objectIndex = entry.semantics.realizationObjectIdx[realization]
+        if (objectIndex === undefined || objectIndex >= entry.semantics.objectCount) {
+          return undefined
+        }
+        return objectIndex
+      }
+    }
+    return entry
+  }
+
+  return {
+    register: (modelId, semantics): void => {
+      entries.set(modelId, makeEntry(modelId, semantics))
+    },
+
+    unregister: (modelId): void => {
+      if (modelId === null) entries.clear()
+      else entries.delete(modelId)
+    },
+
+    bind: (renderer): void => {
+      live = renderer
+    },
+
+    get: (modelId): ViewerModelMaps | null => {
+      const entry = entries.get(modelId)
+      if (!entry) return null
+      // No live range = the model is gone from the scene (or the renderer is
+      // unbound): report not-loaded rather than serve stale global ids.
+      const base = baseOf(modelId)
+      if (base === null) return null
+      if (base !== entry.base) {
+        const shift = base - entry.base
+        for (let i = 0; i < entry.placements.length; i++) entry.placements[i] += shift
+        entry.base = base
+      }
+      return entry.view
+    },
+
+    clear: (): void => {
+      entries.clear()
+      live = null
+    }
+  }
+}

--- a/src/powerbi-visual/src/viewer3/objects/interactions.ts
+++ b/src/powerbi-visual/src/viewer3/objects/interactions.ts
@@ -593,7 +593,7 @@ export const createViewerInteractions = (
     // and reverted: re-slamming on geometry-stream ticks fought the streamer
     // and broke visibility state even on clean loads.
     renderer.on(
-      'viewer:placementsPicked',
+      'viewer:placementPicked',
       ({
         modelId,
         pickResult
@@ -610,7 +610,7 @@ export const createViewerInteractions = (
         }
         const maps = renderer.getModelMaps(modelId)
         if (!maps) return
-        const objectIndex = maps.placementObjectIdx[pickResult.placementIndex]
+        const objectIndex = maps.objectOfPlacement(pickResult.placementIndex)
         if (objectIndex === undefined) return
         const ref: ObjectRef = { modelId, objectIndex }
         if (modifierHeld) toggleIntoSelection([ref])

--- a/src/powerbi-visual/src/viewer3/objects/types.ts
+++ b/src/powerbi-visual/src/viewer3/objects/types.ts
@@ -20,18 +20,25 @@
  */
 
 /**
- * The `.dat`-derived placement↔object maps of one loaded model (the shape of
- * `@speckle/viewer-webgpu`'s `getModelMaps` result): `placementObjectIdx` is
- * the global forward map (placement → dense object index), `objectCsr` the
- * per-model reverse CSR (object index → its global placement ids).
+ * The `.dat`-derived placement↔object maps of one loaded model: `objectCsr` is
+ * the reverse CSR (object index → its global placement ids),
+ * `objectOfPlacement` the forward read (global placement → dense object index).
+ *
+ * viewer-webgpu used to hand this whole shape out of `Renderer.getModelMaps`;
+ * since 2026.8.31 the host rebuilds it from the `viewer:loadArtifactComplete`
+ * realization semantics (see `viewer3/modelMaps.ts`). The forward direction is
+ * a call rather than the old `placementObjectIdx: Uint32Array` because the
+ * host no longer holds a global, all-models placement array to index into —
+ * only per-model lanes plus each model's live placement base.
  */
 export interface ViewerModelMaps {
-  placementObjectIdx: Uint32Array
   objectCsr: {
     offsets: Uint32Array
     placements: Uint32Array
     objectCount: number
   }
+  /** Undefined when the placement isn't this model's, or resolves to no object. */
+  objectOfPlacement(placementIndex: number): number | undefined
 }
 
 /**

--- a/src/powerbi-visual/test/doubleClick.test.ts
+++ b/src/powerbi-visual/test/doubleClick.test.ts
@@ -1,0 +1,94 @@
+import assert from 'node:assert/strict'
+
+import {
+  resolveDoubleClickTarget,
+  type PlacementHit
+} from '../src/viewer3/doubleClick'
+import type { ViewerModelMaps } from '../src/viewer3/objects/types'
+
+/**
+ * Double-click framing. The renderer did this itself until 2026.8.31 and then
+ * stopped, which read as "double-click stopped zooming to selection" — the
+ * host now owns the gesture, so it needs its own coverage.
+ */
+
+const MODEL_ID = 'bundle_version-1'
+const BASE = 100
+
+/** Model with 3 placements over 2 objects, based at global placement 100. */
+const maps: ViewerModelMaps = {
+  objectCsr: {
+    offsets: new Uint32Array([0, 2, 3]),
+    placements: new Uint32Array([BASE, BASE + 2, BASE + 1]),
+    objectCount: 2
+  },
+  objectOfPlacement: (placementIndex) => {
+    const local = placementIndex - BASE
+    if (local < 0 || local > 2) return undefined
+    return local === 1 ? 1 : 0
+  }
+}
+
+const resolve = (
+  hits: PlacementHit[] | null,
+  overrides: Partial<Parameters<typeof resolveDoubleClickTarget>[0]> = {}
+) =>
+  resolveDoubleClickTarget({
+    hits,
+    firstVisibleHit: (candidates) => candidates[0] ?? null,
+    modelAt: (placementIndex) =>
+      placementIndex >= BASE && placementIndex < BASE + 3 ? MODEL_ID : null,
+    getModelMaps: (modelId) => (modelId === MODEL_ID ? maps : null),
+    ...overrides
+  })
+
+const main = () => {
+  assert.deepEqual(
+    resolve([{ placementIndex: BASE + 1 }]),
+    { kind: 'object', group: { modelId: MODEL_ID, objectIndexes: [1] } },
+    'a hit frames the object that owns the picked placement'
+  )
+
+  // The whole object, not the picked primitive: object 0 owns placements 100
+  // and 102, and framing must cover both however it was hit.
+  assert.deepEqual(
+    resolve([{ placementIndex: BASE + 2 }]),
+    { kind: 'object', group: { modelId: MODEL_ID, objectIndexes: [0] } },
+    'any placement of an object resolves to that one object'
+  )
+
+  assert.deepEqual(resolve([]), { kind: 'extents' }, 'empty space zooms extents')
+  assert.deepEqual(resolve(null), { kind: 'extents' }, 'a missing hit list is a miss')
+
+  // Visibility: the renderer's filter is what stops a double-click from flying
+  // to something hidden, isolated away or filtered out behind the cursor.
+  assert.deepEqual(
+    resolve([{ placementIndex: BASE }], { firstVisibleHit: () => null }),
+    { kind: 'none' },
+    'hits that are all invisible leave the camera alone'
+  )
+
+  // Not zoom-extents: hits existed, so this was NOT an empty-space click, and
+  // treating it as one would fly the camera out from under the user.
+  assert.notDeepEqual(
+    resolve([{ placementIndex: BASE }], { firstVisibleHit: () => null }),
+    { kind: 'extents' },
+    'an all-invisible hit list must not be mistaken for empty space'
+  )
+
+  assert.deepEqual(
+    resolve([{ placementIndex: 9999 }], { modelAt: () => null }),
+    { kind: 'none' },
+    'a placement owned by no loaded model resolves to nothing'
+  )
+
+  assert.deepEqual(
+    resolve([{ placementIndex: BASE }], { getModelMaps: () => null }),
+    { kind: 'none' },
+    'a model with no maps yet resolves to nothing'
+  )
+
+  console.log('double click framing tests passed')
+}
+
+main()

--- a/src/powerbi-visual/test/modelMaps.test.ts
+++ b/src/powerbi-visual/test/modelMaps.test.ts
@@ -1,0 +1,102 @@
+import assert from 'node:assert/strict'
+
+import { createModelMapsCache, type SemanticMaps } from '../src/viewer3/modelMaps'
+import type { Renderer } from '@speckle/viewer-webgpu'
+
+/**
+ * The maps cache rebuilds what viewer-webgpu stopped handing out in 2026.8.31:
+ * a per-model object→placement CSR in GLOBAL placement ids, derived from
+ * model-local realization semantics plus the model's live placement base.
+ *
+ * Two properties matter and neither is exercised by the paint tests:
+ *  - the counting sort groups a model's placements by owning object, including
+ *    instanced realizations that share one object;
+ *  - the global ids follow the placement base when an earlier model unloads
+ *    and the renderer compacts the placement SoA underneath us.
+ */
+
+/** Just enough Renderer to answer placement-range questions. */
+const fakeRenderer = (ranges: Map<string, [number, number]>): Renderer =>
+  ({
+    getModelPlacementRange: (modelId: string) => ranges.get(modelId) ?? null
+  }) as unknown as Renderer
+
+const main = () => {
+  // Model A: 5 placements over 3 objects. Realizations 0 and 3 both belong to
+  // object 0 (an instanced object) — the case a naive realization→object
+  // identity mapping would get wrong.
+  //   placement: 0    1    2    3    4
+  //   realization: 0  1    3    2    0
+  //   object:      0  1    0    2    0
+  const semantics: SemanticMaps = {
+    placementRealizationIdx: new Uint32Array([0, 1, 3, 2, 0]),
+    realizationObjectIdx: new Uint32Array([0, 1, 2, 0]),
+    objectCount: 3
+  }
+
+  const ranges = new Map<string, [number, number]>([
+    ['model-a', [100, 105]],
+    ['model-b', [0, 100]]
+  ])
+  const cache = createModelMapsCache()
+  cache.bind(fakeRenderer(ranges))
+  cache.register('model-a', semantics)
+
+  const maps = cache.get('model-a')
+  assert.ok(maps, 'a registered model with a live range resolves')
+  assert.equal(maps.objectCsr.objectCount, 3)
+
+  /** The global placement ids of one object, as paint would expand them. */
+  const placementsOf = (objectIndex: number): number[] => {
+    const { offsets, placements } = maps.objectCsr
+    return Array.from(placements.slice(offsets[objectIndex], offsets[objectIndex + 1]))
+  }
+
+  // Base 100, so model-local p becomes global 100 + p.
+  assert.deepEqual(placementsOf(0), [100, 102, 104], 'instanced object gathers all three')
+  assert.deepEqual(placementsOf(1), [101])
+  assert.deepEqual(placementsOf(2), [103])
+
+  // Forward direction: the pick path hands in a global id.
+  assert.equal(maps.objectOfPlacement(100), 0)
+  assert.equal(maps.objectOfPlacement(103), 2)
+  assert.equal(maps.objectOfPlacement(104), 0)
+  assert.equal(maps.objectOfPlacement(99), undefined, 'below the range is not ours')
+  assert.equal(maps.objectOfPlacement(105), undefined, 'above the range is not ours')
+
+  // Unloading model-b compacts the SoA: model-a's 100 placements shift to 0.
+  // The cache must re-read the range and rebase, or every paint lands on
+  // whatever now occupies 100..104.
+  ranges.delete('model-b')
+  ranges.set('model-a', [0, 5])
+
+  const shifted = cache.get('model-a')
+  assert.ok(shifted)
+  assert.deepEqual(placementsOf(0), [0, 2, 4], 'CSR rebases onto the new base')
+  assert.deepEqual(placementsOf(1), [1])
+  assert.equal(shifted.objectOfPlacement(0), 0, 'forward read rebases too')
+  assert.equal(shifted.objectOfPlacement(100), undefined, 'the old ids are stale')
+
+  // A model with no live range is gone from the scene — better to report
+  // not-loaded than to serve placement ids that now belong to someone else.
+  ranges.delete('model-a')
+  assert.equal(cache.get('model-a'), null, 'no live range = not loaded')
+
+  ranges.set('model-a', [0, 5])
+  assert.ok(cache.get('model-a'), 'the entry survives a transient missing range')
+
+  cache.unregister('model-a')
+  assert.equal(cache.get('model-a'), null, 'unregistered models are gone')
+
+  // Null artifact id on the unload event = the whole scene dropped.
+  cache.register('model-a', semantics)
+  cache.register('model-c', semantics)
+  ranges.set('model-c', [0, 5])
+  cache.unregister(null)
+  assert.equal(cache.get('model-a'), null)
+  assert.equal(cache.get('model-c'), null)
+
+  console.log('model maps cache tests passed')
+}
+
+main()

--- a/src/powerbi-visual/test/modelReadyColorReplay.test.ts
+++ b/src/powerbi-visual/test/modelReadyColorReplay.test.ts
@@ -37,12 +37,12 @@ const main = async () => {
   assert.equal(paintedColors.length, 0, 'colors cannot paint before model maps exist')
 
   modelMaps = {
-    placementObjectIdx: new Uint32Array([0]),
     objectCsr: {
       offsets: new Uint32Array([0, 1]),
       placements: new Uint32Array([7]),
       objectCount: 1
-    }
+    },
+    objectOfPlacement: (placementIndex) => (placementIndex === 7 ? 0 : undefined)
   }
 
   for (const handler of eventHandlers.get('viewer:loadArtifactComplete') ?? []) {

--- a/src/powerbi-visual/test/pickSelection.test.ts
+++ b/src/powerbi-visual/test/pickSelection.test.ts
@@ -1,0 +1,119 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { createRendererBridge } from '../src/viewer3/bridge'
+import { createViewerInteractions } from '../src/viewer3/objects/interactions'
+import type { SemanticMaps } from '../src/viewer3/modelMaps'
+import type { Renderer } from '@speckle/viewer-webgpu'
+
+/**
+ * Click-to-select, end to end through the bridge.
+ *
+ * This path is only exercised by real events, and every part of it is
+ * string-keyed (`ViewerHandle.on` takes `event: string`, payloads are `any`),
+ * so the compiler cannot see a viewer-side rename. It has bitten twice:
+ * 2026.8.28 renamed `viewer:placementsPicked` → `viewer:placementPicked`, and
+ * 2026.8.31 moved the placement→object map out of the renderer entirely.
+ * Both showed up as "clicking does nothing", with no error anywhere.
+ */
+
+/** Model with 3 placements over 2 objects, based at global placement 100. */
+const semanticMaps: SemanticMaps = {
+  placementRealizationIdx: new Uint32Array([0, 1, 0]),
+  realizationObjectIdx: new Uint32Array([0, 1]),
+  objectCount: 2
+}
+const MODEL_ID = 'bundle_version-1'
+const BASE = 100
+
+const fakeRenderer = (): Renderer =>
+  ({
+    getModelPlacementRange: (modelId: string) =>
+      modelId === MODEL_ID ? [BASE, BASE + 3] : null,
+    setColor: () => undefined,
+    resetMaterialBatched: () => undefined,
+    hideObjects: () => undefined,
+    showObjects: () => undefined,
+    requestRender: () => undefined
+  }) as unknown as Renderer
+
+const testPickSelectsTheObjectUnderTheCursor = async () => {
+  const bridge = createRendererBridge()
+  bridge.bind(fakeRenderer())
+  const interactions = createViewerInteractions({ renderer: bridge.handle })
+
+  bridge.emitter.emit('viewer:loadArtifactComplete', {
+    artifactId: MODEL_ID,
+    loadTime: 0,
+    semanticMaps
+  })
+  await Promise.resolve()
+
+  // Global placement 101 is the model's local placement 1 → realization 1 → object 1.
+  bridge.emitter.emit('viewer:placementPicked', {
+    modelId: MODEL_ID,
+    pickResult: { placementIndex: BASE + 1 }
+  })
+  await Promise.resolve()
+
+  assert.deepEqual(
+    interactions.getSnapshot().selection,
+    [{ modelId: MODEL_ID, objectIndex: 1 }],
+    'a pick must resolve the global placement to its object and select it'
+  )
+
+  // A miss clears the selection (a plain click on empty space).
+  bridge.emitter.emit('viewer:placementPicked', { modelId: '', pickResult: null })
+  await Promise.resolve()
+  assert.deepEqual(
+    interactions.getSnapshot().selection,
+    [],
+    'a pick miss clears the selection'
+  )
+
+  interactions.dispose()
+}
+
+/**
+ * Every `viewer:*` event this codebase subscribes to must actually be emitted
+ * by the installed viewer build. Catches the rename class wholesale, including
+ * events no test drives.
+ */
+const testSubscribedEventsExistInTheViewerBundle = () => {
+  const sources = [
+    'src/plugins/viewer.ts',
+    'src/viewer3/bridge.ts',
+    'src/viewer3/objects/interactions.ts'
+  ]
+  const bundle = readFileSync(
+    join(__dirname, '..', 'node_modules/@speckle/viewer-webgpu/dist/index.js'),
+    'utf8'
+  )
+  const emitted = new Set(
+    Array.from(bundle.matchAll(/"(viewer:[a-zA-Z]+)"/g), (match) => match[1])
+  )
+  assert.ok(emitted.size > 0, 'the viewer bundle must declare some events')
+
+  const subscribed = new Set<string>()
+  for (const source of sources) {
+    const text = readFileSync(join(__dirname, '..', source), 'utf8')
+    for (const match of text.matchAll(/'(viewer:[a-zA-Z]+)'/g)) subscribed.add(match[1])
+  }
+  assert.ok(subscribed.size > 0, 'the sources must subscribe to some events')
+
+  const missing = Array.from(subscribed).filter((event) => !emitted.has(event))
+  assert.deepEqual(
+    missing,
+    [],
+    `subscribed to viewer events the installed viewer never emits: ${missing.join(', ')}`
+  )
+}
+
+const main = async () => {
+  await testPickSelectsTheObjectUnderTheCursor()
+  testSubscribedEventsExistInTheViewerBundle()
+  console.log('pick selection tests passed')
+}
+
+void main()

--- a/src/powerbi-visual/test/tsconfig.viewer3.json
+++ b/src/powerbi-visual/test/tsconfig.viewer3.json
@@ -3,5 +3,11 @@
   "ts-node": {
     "experimentalResolver": true
   },
-  "include": ["./modelReadyColorReplay.test.ts", "../src/viewer3/objects/**/*.ts"]
+  "include": [
+    "./modelReadyColorReplay.test.ts",
+    "./modelMaps.test.ts",
+    "./pickSelection.test.ts",
+    "./doubleClick.test.ts",
+    "../src/viewer3/**/*.ts"
+  ]
 }


### PR DESCRIPTION
Bumps `@speckle/viewer-tools` and `@speckle/viewer-webgpu` from 2026.8.21 to 2026.9.0 and migrates the three breaking changes that jump carries.

Two of the three are invisible to the compiler. `ViewerHandle.on` is typed `(event: string, payload: any)`, so a renamed event is just a subscription that never fires.

## Maps (2026.8.31)

`Renderer.getModelMaps` is gone. The object CSR it returned now arrives as model-local realization arrays, delivered once in the `viewer:loadArtifactComplete` payload, and the host holds them.

`viewer3/modelMaps.ts` rebuilds the old contract with a counting sort per load, plus a rebase against the live placement range on every read. The renderer used to shift its own CSR when an earlier model unloaded and compacted the placement SoA. Nothing does that for us now, and a stale base paints the wrong geometry without raising an error.

`ViewerModelMaps.placementObjectIdx` becomes `objectOfPlacement()`, because there is no longer a global all-models placement array to index into.

## Picking (2026.8.28)

`viewer:placementsPicked` was renamed to `viewer:placementPicked`. Both subscriptions were left on the old name, so no pick listener fired and click selection did nothing.

## Double click (2026.8.31)

The renderer no longer zooms to the picked object. It only emits `viewer:doubleClickIntersectResult`. `viewer3/doubleClick.ts` restores the framing and fixes two things the old renderer path got wrong. It resolves the first visible hit, where the renderer used `hits[0]` and could fly to geometry that is hidden, isolated away or filtered out behind the cursor. And it frames the whole object rather than the single picked primitive.

This also drops `renderer.onDoubleClickMiss`. The renderer declares the property but no shipped build has ever invoked it, so the zoom extents it claimed to wire up never ran. A miss now arrives as an empty hit list and is handled with the rest of the gesture.

## Tests

`pickSelection.test.ts` walks the pick path end to end and asserts that every `viewer:*` event these sources subscribe to is actually emitted by the installed viewer bundle. That catches the whole rename class, not one rename at a time. `modelMaps.test.ts` and `doubleClick.test.ts` cover the two new modules.

Run with `npm test` in `src/powerbi-visual`.
